### PR TITLE
Check home dir of the user running the script instead of its owner

### DIFF
--- a/CRM/Civioffice/Configuration.php
+++ b/CRM/Civioffice/Configuration.php
@@ -190,11 +190,10 @@ class CRM_Civioffice_Configuration
             return $_SERVER['HOME'];
         }
 
-        // try via shell
-        $user_name = get_current_user();
-        exec("eval echo \"~{$user_name}\"", $eval_output);
-        if (!empty($eval_output[0])) {
-            return $eval_output[0];
+        // Get process user's home directory.
+        $user_info = posix_getpwuid(posix_getuid());
+        if (!empty($user_info['dir'])) {
+            return $user_info['dir'];
         }
 
         // todo: what else to check?


### PR DESCRIPTION
Configuring the unoconv renderer fails if the script is not being owned by the webserver user, resulting in CiviOffice checking the wrong home directory for `.cache` and `.config` directories. CiviOffice assumes the PHP script being owned by the webserver, which usually should not be the case.

I'm not aware of the entire picture around this, but checking the home directory of the user running the script seems more appropriate to me, however, this will also fail if the script is not being run by the webserver.