### PR TITLE
Add an option for whether to "prepare"/"repair" DOCX documents prior to token replacement

### DIFF
--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -109,11 +109,19 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
             false
         );
 
+        $form->add(
+            'checkbox',
+            'attachments--' . $attachment_id . '--prepare_docx',
+            E::ts('Prepare DOCX documents'),
+            false
+        );
+
         return [
             'attachments--' . $attachment_id . '--document_renderer_uri' => 'attachment-civioffice_document-document_renderer_uri',
             'attachments--' . $attachment_id . '--document_uri' => 'attachment-civioffice_document-document_uri',
             'attachments--' . $attachment_id . '--target_mime_type' => 'attachment-civioffice_document-target_mime_type',
             'attachments--' . $attachment_id . '--name' => 'attachment-civioffice_document-name',
+            'attachments--' . $attachment_id . '--prepare_docx' => 'attachment-civioffice_document-prepare_docx',
         ] + array_fill_keys($live_snippet_elements, 'attachment-civioffice_document-live_snippet');
     }
 
@@ -135,6 +143,7 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
             'target_mime_type' => $values['attachments--' . $attachment_id . '--target_mime_type'],
             'name' => $values['attachments--' . $attachment_id . '--name'],
             'live_snippets' => $live_snippet_values,
+            'prepare_docx' => !empty($values['attachments--' . $attachment_id . '--prepare_docx'])
         ];
     }
 
@@ -151,6 +160,7 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
                 'renderer_uri' => $attachment_values['document_renderer_uri'],
                 'target_mime_type' => $attachment_values['target_mime_type'],
                 'live_snippets' => $attachment_values['live_snippets'],
+                'prepare_docx' => $attachment_values['prepare_docx'],
             ]
         );
         if (!empty($civioffice_result['is_error']) || empty($civioffice_result['values'][0])) {

--- a/CRM/Civioffice/ConversionJob.php
+++ b/CRM/Civioffice/ConversionJob.php
@@ -57,6 +57,13 @@ class CRM_Civioffice_ConversionJob
     protected $live_snippets;
 
     /**
+     * @var bool $prepare_docx
+     *   Whether to run the DOCX document through the converter prior to processing in order to optimise/repair possibly
+     *   corrupted CiviCRM tokens in the document.
+     */
+    protected $prepare_docx;
+
+    /**
      * @var string $title
      *   Title for runner state
      */
@@ -70,7 +77,8 @@ class CRM_Civioffice_ConversionJob
         $entity_type,
         $target_mime_type,
         $title,
-        $live_snippets = []
+        $live_snippets = [],
+        $prepare_docx = false
     )
     {
         $this->renderer_uri = $renderer_uri;
@@ -81,6 +89,7 @@ class CRM_Civioffice_ConversionJob
         $this->target_mime_type = $target_mime_type;
         $this->title = $title;
         $this->live_snippets = $live_snippets;
+        $this->prepare_docx = $prepare_docx;
     }
 
     public function run(): bool
@@ -93,6 +102,7 @@ class CRM_Civioffice_ConversionJob
             'renderer_uri'     => $this->renderer_uri,
             'target_mime_type' => $this->target_mime_type,
             'live_snippets' => $this->live_snippets,
+            'prepare_docx' => $this->prepare_docx
         ]);
 
         $result_store_uri = $render_result['values'][0];

--- a/CRM/Civioffice/Form/DocumentFromSingleContact.php
+++ b/CRM/Civioffice/Form/DocumentFromSingleContact.php
@@ -102,6 +102,12 @@ class CRM_Civioffice_Form_DocumentFromSingleContact extends CRM_Core_Form
         );
 
         $this->add(
+            'checkbox',
+            'prepare_docx',
+            E::ts("Prepare DOCX documents")
+        );
+
+        $this->add(
             'select',
             'activity_type_id',
             E::ts("Create Activity"),
@@ -162,6 +168,7 @@ class CRM_Civioffice_Form_DocumentFromSingleContact extends CRM_Core_Form
             'renderer_uri' => $values['document_renderer_uri'],
             'target_mime_type' => $values['target_mime_type'],
             'live_snippets' => $live_snippets,
+            'prepare_docx' => !empty($values['prepare_docx']),
         ]);
         $result_store_uri = $render_result['values'][0];
         $result_store = CRM_Civioffice_Configuration::getDocumentStore($result_store_uri);

--- a/CRM/Civioffice/Form/Task/CreateDocuments.php
+++ b/CRM/Civioffice/Form/Task/CreateDocuments.php
@@ -81,6 +81,12 @@ class CRM_Civioffice_Form_Task_CreateDocuments extends CRM_Contact_Form_Task
         );
 
         $this->add(
+            'checkbox',
+            'prepare_docx',
+            E::ts("Prepare DOCX documents")
+        );
+
+        $this->add(
             'select',
             'batch_size',
             E::ts("batch size for processing"),
@@ -139,7 +145,8 @@ class CRM_Civioffice_Form_Task_CreateDocuments extends CRM_Contact_Form_Task
                     'contact',
                     $values['target_mime_type'],
                     E::ts('Initialized'),
-                    $live_snippets
+                    $live_snippets,
+                    !empty($values['prepare_docx'])
                 )
             );
         }

--- a/api/v3/CiviOffice/Convert.php
+++ b/api/v3/CiviOffice/Convert.php
@@ -67,6 +67,12 @@ function _civicrm_api3_civi_office_convert_spec(&$spec)
         'title' => E::ts('Live Snippets'),
         'description' => E::ts('Contents for tokens referring to configured Live Snippets.'),
     ];
+    $spec['prepare_docx'] = [
+        'name' => 'prepare_docx',
+        'type' => CRM_Utils_Type::T_BOOLEAN,
+        'title' => E::ts('Prepare DOCX documents'),
+        'description' => E::ts('Run the DOCX document through the converter prior to processing in order to optimise/repair possibly corrupted CiviCRM tokens in the document.'),
+    ];
 }
 
 /**
@@ -86,6 +92,7 @@ function civicrm_api3_civi_office_convert($params)
     $renderer_uri = $params['renderer_uri'];
     $target_mime_type = $params['target_mime_type'];
     $live_snippets = $params['live_snippets'];
+    $prepare_docx = $params['prepare_docx'];
 
     $configuration = CRM_Civioffice_Configuration::getConfig();
     $document_renderer = $configuration->getDocumentRenderer($renderer_uri);
@@ -93,7 +100,15 @@ function civicrm_api3_civi_office_convert($params)
 
     $temp_store = new CRM_Civioffice_DocumentStore_LocalTemp($target_mime_type);
 
-    $documents = $document_renderer->render($document, $entity_ids, $temp_store, $target_mime_type, $entity_type, $live_snippets);
+    $documents = $document_renderer->render(
+        $document,
+        $entity_ids,
+        $temp_store,
+        $target_mime_type,
+        $entity_type,
+        $live_snippets,
+        $prepare_docx
+    );
 
     return civicrm_api3_create_success([$temp_store->getURI()], $params, 'CiviOffice', 'convert');
 }

--- a/templates/CRM/Civioffice/Form/DocumentFromSingleContact.tpl
+++ b/templates/CRM/Civioffice/Form/DocumentFromSingleContact.tpl
@@ -39,6 +39,12 @@
       <div class="clear"></div>
     </div>
 
+    <div class="crm-section">
+      <div class="label">{$form.prepare_docx.label}</div>
+      <div class="content">{$form.prepare_docx.html}</div>
+      <div class="clear"></div>
+    </div>
+
     <div class="crm-accordion-wrapper">
 
       <div class="crm-accordion-header">{ts}Activity{/ts}</div>

--- a/templates/CRM/Civioffice/Form/Task/CreateDocuments.tpl
+++ b/templates/CRM/Civioffice/Form/Task/CreateDocuments.tpl
@@ -40,6 +40,12 @@
     </div>
 
     <div class="crm-section">
+      <div class="label">{$form.prepare_docx.label}</div>
+      <div class="content">{$form.prepare_docx.html}</div>
+      <div class="clear"></div>
+    </div>
+
+    <div class="crm-section">
       <div class="label">{$form.batch_size.label}</div>
       <div class="content">{$form.batch_size.html}</div>
       <div class="clear"></div>


### PR DESCRIPTION
… by running the document through the converter without changing format prior to finally converting it.