### PR TITLE
Mail Attachment provider for attaching CiviOffice documents to e-mail

### DIFF
--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -35,6 +35,9 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         $event->attachment_types['civioffice_document'] = [
             'label' => E::ts('CiviOffice Document'),
             'controller' => self::class,
+            'context' => [
+                'entity_types' => ['contact', 'contribution'],
+            ],
         ];
     }
 

--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -193,10 +193,15 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         $result_store = CRM_Civioffice_Configuration::getDocumentStore($result_store_uri);
         foreach ($result_store->getDocuments() as $document) {
             $attachment_file = $document->getLocalTempCopy();
+            $mime_type = Attachments::getMimeType($attachment_file);
+            $file_extension = CRM_Civioffice_MimeType::mapMimeTypeToFileExtension($mime_type);
+            if (!empty($name_parts = explode('.', $attachment_values['name'])) && end($name_parts) != $file_extension) {
+                $attachment_values['name'] .= '.' . $file_extension;
+            }
             $attachment = [
                 'fullPath' => $attachment_file,
-                'mime_type' => Attachments::getMimeType($attachment_file),
-                'cleanName' => $attachment_values['name'],
+                'mime_type' => $mime_type,
+                'cleanName' => $attachment_values['name'] ?: $document->getName(),
             ];
         }
         return $attachment ?? null;

--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -44,7 +44,7 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
     /**
      * {@inheritDoc}
      */
-    public static function buildAttachmentForm(&$form, $attachment_id, $prefix = '')
+    public static function buildAttachmentForm(&$form, $attachment_id, $prefix = '', $defaults = [])
     {
         $config = CRM_Civioffice_Configuration::getConfig();
 
@@ -104,7 +104,8 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         // Add Live Snippets.
         $live_snippet_elements = CRM_Civioffice_LiveSnippets::addFormElements(
             $form,
-            $prefix . 'attachments--' . $attachment_id . '--'
+            $prefix . 'attachments--' . $attachment_id . '--',
+            $defaults['live_snippets']
         );
 
         $form->add(
@@ -120,6 +121,16 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
             $prefix . 'attachments--' . $attachment_id . '--prepare_docx',
             E::ts('Prepare DOCX documents'),
             false
+        );
+
+        $form->setDefaults(
+            [
+                $prefix . 'attachments--' . $attachment_id . '--document_renderer_uri' => $defaults['document_renderer_uri'],
+                $prefix . 'attachments--' . $attachment_id . '--document_uri' => $defaults['document_uri'],
+                $prefix . 'attachments--' . $attachment_id . '--target_mime_type' => $defaults['target_mime_type'],
+                $prefix . 'attachments--' . $attachment_id . '--name' => $defaults['name'],
+                $prefix . 'attachments--' . $attachment_id . '--prepare_docx' => $defaults['prepare_docx'],
+            ]
         );
 
         return [

--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -15,8 +15,8 @@
 
 use CRM_Civioffice_ExtensionUtil as E;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Civi\Mailbatch\AttachmentType\AttachmentTypeInterface;
-use Civi\Mailbatch\Form\Task\AttachmentsTrait;
+use Civi\Mailattachment\AttachmentType\AttachmentTypeInterface;
+use Civi\Mailattachment\Form\Task\AttachmentsTrait;
 
 class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, AttachmentTypeInterface
 {
@@ -26,7 +26,7 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
     public static function getSubscribedEvents()
     {
         return [
-            'civi.mailbatch.attachmentTypes' => 'getAttachmentTypes',
+            'civi.mailattachment.attachmentTypes' => 'getAttachmentTypes',
         ];
     }
 
@@ -41,6 +41,10 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         ];
     }
 
+    /**
+     * @param \CRM_Core_Form $form
+     * @param int $attachment_id
+     */
     public static function buildAttachmentForm(&$form, $attachment_id)
     {
         $config = CRM_Civioffice_Configuration::getConfig();
@@ -128,8 +132,9 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         ] + array_fill_keys($live_snippet_elements, 'attachment-civioffice_document-live_snippet');
     }
 
-    public static function getAttachmentFormTemplate() {
-        return 'CRM/Civioffice/Form/AttachmentProvider.tpl';
+    public static function getAttachmentFormTemplate($type = 'tpl')
+    {
+        return in_array($type, ['tpl', 'hlp']) ? 'CRM/Civioffice/Form/AttachmentProvider.' . $type : null;
     }
 
     public static function processAttachmentForm(&$form, $attachment_id)

--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -195,8 +195,16 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
             $attachment_file = $document->getLocalTempCopy();
             $mime_type = Attachments::getMimeType($attachment_file);
             $file_extension = CRM_Civioffice_MimeType::mapMimeTypeToFileExtension($mime_type);
-            if (!empty($name_parts = explode('.', $attachment_values['name'])) && end($name_parts) != $file_extension) {
+
+            if (
+                !empty($attachment_values['name'])
+                && !empty($name_parts = explode('.', $attachment_values['name']))
+                && end($name_parts) != $file_extension
+            ) {
                 $attachment_values['name'] .= '.' . $file_extension;
+            }
+            else {
+                $attachment_values['name'] = $document->getName();
             }
             $attachment = [
                 'fullPath' => $attachment_file,

--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -149,14 +149,13 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
 
     public static function buildAttachment($context, $attachment_values)
     {
-        $entity_id = $context['contact']['id'] ?? null;
         $civioffice_result = civicrm_api3(
             'CiviOffice',
             'convert',
             [
                 'document_uri' => $attachment_values['document_uri'],
-                'entity_ids' => $entity_id ? [$entity_id] : [],
-                'entity_type' => isset($context['contact']) ? 'contact' : null,
+                'entity_ids' => [$context['entity_id']],
+                'entity_type' => $context['entity_type'],
                 'renderer_uri' => $attachment_values['document_renderer_uri'],
                 'target_mime_type' => $attachment_values['target_mime_type'],
                 'live_snippets' => $attachment_values['live_snippets'],

--- a/CRM/Civioffice/DocumentRenderer/LocalUnoconv.php
+++ b/CRM/Civioffice/DocumentRenderer/LocalUnoconv.php
@@ -306,7 +306,7 @@ class CRM_Civioffice_DocumentRenderer_LocalUnoconv extends CRM_Civioffice_Docume
          */
 
         if (isset($prepared_document)) {
-            exec('rm ' . $prepared_document->getAbsolutePath());
+            exec('rm "' . $prepared_document->getAbsolutePath() . '"');
         }
 
         if (!$needs_conversion) {

--- a/CRM/Civioffice/LiveSnippets.php
+++ b/CRM/Civioffice/LiveSnippets.php
@@ -105,11 +105,11 @@ class CRM_Civioffice_LiveSnippets
      * @param CRM_Core_Form $form
      * @param $defaults
      */
-    public static function addFormElements(&$form, $name_prefix = '') {
+    public static function addFormElements(&$form, $name_prefix = '', $defaults = []) {
         $live_snippet_elements = [];
         $live_snippet_descriptions = [];
         $live_snippet_values = CRM_Civioffice_LiveSnippets::getValues();
-        $defaults = [];
+        $default_values = [];
         $element_names = [];
         foreach (CRM_Civioffice_LiveSnippets::get() as $live_snippet) {
             $element_name = $name_prefix . 'live_snippets_' . $live_snippet['name'];
@@ -119,13 +119,13 @@ class CRM_Civioffice_LiveSnippets
                 $live_snippet['label']
             );
             $element_names[] = $element_name;
-            $defaults[$element_name] = $live_snippet_values[$live_snippet['name']];
+            $default_values[$element_name] = $defaults[$live_snippet['name']] ?? $live_snippet_values[$live_snippet['name']];
             $live_snippet_elements[$live_snippet['name']] = 'live_snippets_' . $live_snippet['name'];
             $live_snippet_descriptions[$live_snippet['name']] = $live_snippet['description'];
         }
         $form->assign('live_snippet_elements', $live_snippet_elements);
         $form->assign('live_snippet_descriptions', $live_snippet_descriptions);
-        $form->setDefaults($defaults);
+        $form->setDefaults($default_values);
         return $element_names;
     }
 

--- a/civioffice.php
+++ b/civioffice.php
@@ -55,7 +55,7 @@ function civioffice_civicrm_config(&$config)
 
     \Civi::dispatcher()->addSubscriber(new CRM_Civioffice_Tokens('civioffice'));
 
-    if (interface_exists('\Civi\Mailbatch\AttachmentType\AttachmentTypeInterface')) {
+    if (interface_exists('\Civi\Mailattachment\AttachmentType\AttachmentTypeInterface')) {
         \Civi::dispatcher()->addSubscriber(new CRM_Civioffice_AttachmentProvider());
     }
 }

--- a/templates/CRM/Civioffice/Form/AttachmentProvider.hlp
+++ b/templates/CRM/Civioffice/Form/AttachmentProvider.hlp
@@ -1,0 +1,21 @@
+{*-------------------------------------------------------+
+| SYSTOPIA CiviOffice Integration                        |
+| Copyright (C) 2022 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{crmScope extensionKey='de.systopia.civioffice'}
+
+{htxt id='id-attachment-civioffice_document-prepare_docx'}
+  <p>{ts}Run the DOCX document through the converter prior to processing in order to optimise/repair possibly corrupted CiviCRM tokens in the document.{/ts}</p>
+{/htxt}
+
+{/crmScope}

--- a/templates/CRM/Civioffice/Form/AttachmentProvider.tpl
+++ b/templates/CRM/Civioffice/Form/AttachmentProvider.tpl
@@ -26,7 +26,8 @@
       <div class="label">
           {$form.$attachment_element.label}
           {capture assign="help_id"}id-{$attachment_element_type}{/capture}
-          {help id=$help_id title=$form.$attachment_element.label}
+          {capture assign="help_file"}{$attachment.help_template}{/capture}
+          {help id=$help_id title=$form.$attachment_element.label file=$help_file}
       </div>
       <div class="content">{$form.$attachment_element.html}</div>
       <div class="clear"></div>


### PR DESCRIPTION
Follow-up to #12.

This implements the attachment type interface of [systopia/de.systopia.mailattachment](https://github.com/systopia/de.systopia.mailattachment), which has been migrated there from [systopia/de.systopia.mailbatch](https://github.com/systopia/de.systopia.mailbatch).

Also, this explicitly denotes the entity types for which the implementation has support (currently contribution and contact).