### PR TITLE
Allow converting HTML to OOXML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+/vendor/
 /.idea/
+composer.lock

--- a/CRM/Civioffice/Configuration.php
+++ b/CRM/Civioffice/Configuration.php
@@ -78,7 +78,8 @@ class CRM_Civioffice_Configuration
     {
         // todo: get from config
         $available_renderers = [
-            new CRM_Civioffice_DocumentRenderer_LocalUnoconv()
+            new CRM_Civioffice_DocumentRenderer_LocalUnoconv(),
+            new CRM_Civioffice_DocumentRenderer_LocalUnoconvPhpWord(),
         ];
 
         if (!$only_show_active) return $available_renderers;

--- a/CRM/Civioffice/DocumentRenderer/LocalUnoconvPhpWord/TemplateProcessor.php
+++ b/CRM/Civioffice/DocumentRenderer/LocalUnoconvPhpWord/TemplateProcessor.php
@@ -1,0 +1,42 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA CiviOffice Integration                        |
+| Copyright (C) 2020 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*/
+
+use CRM_Civioffice_ExtensionUtil as E;
+use PhpOffice\PhpWord;
+
+class CRM_Civioffice_DocumentRenderer_LocalUnoconvPhpWord_TemplateProcessor extends PhpWord\TemplateProcessor
+{
+    /**
+     *
+     */
+    public function liveSnippetTokensToMacros()
+    {
+        $this->tempDocumentHeaders = preg_replace(
+            '/({civioffice\.live_snippets\..*?})/',
+            '\$$1',
+            $this->tempDocumentHeaders
+        );
+        $this->tempDocumentMainPart = preg_replace(
+            '/(\{civioffice\.live_snippets\..*?\})/',
+            '\$$1',
+            $this->tempDocumentMainPart
+        );
+        $this->tempDocumentFooters = preg_replace(
+            '/({civioffice\.live_snippets\..*?})/',
+            '\$$1',
+            $this->tempDocumentFooters
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "systopia/de.systopia.civioffice",
+    "description": "CiviCRM integration for various exchangeable office suites",
+    "license": "AGPL-3.0",
+    "authors": [
+        {
+            "name": "SYSTOPIA",
+            "email": "info@systopia.de"
+        }
+    ],
+    "require": {
+        "phpoffice/phpword": "^0.18.3"
+    }
+}


### PR DESCRIPTION
This provides another LocalUnoconv document renderer that implements the [PhpWord library](https://github.com/PHPOffice/PHPWord) for converting HTML contents to OOXML (DOCX). This is currently limited to Live Snippets contents and to HTML elements for which conversion is [provided by PhpWord](https://github.com/PHPOffice/PHPWord/blob/be0190cd5d8f95b4be08d5853b107aa4e352759a/src/PhpWord/Shared/Html.php#L166-L198).

This might need a follow-up for merging both LocalUnoconv document renderers with an option for whether to perform HTML conversion.