### PR TITLE
Provide list of tokens CiviOffice can replace

### DIFF
--- a/CRM/Civioffice/Page/Tokens.php
+++ b/CRM/Civioffice/Page/Tokens.php
@@ -1,0 +1,40 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA CiviOffice Integration                        |
+| Copyright (C) 2022 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*/
+
+use Civi\Token\TokenProcessor;
+use CRM_Civioffice_ExtensionUtil as E;
+
+class CRM_Civioffice_Page_Tokens extends CRM_Core_Page
+{
+    public function run()
+    {
+        $tokenProcessor = new TokenProcessor(
+            Civi::service('dispatcher'),
+            [
+                'schema' => [
+                    'contactId',
+                    'contributionId',
+                    'participantId',
+                    'eventId',
+                ],
+                'controller' => __CLASS__,
+                'smarty' => false,
+            ]
+        );
+        $this->assign('tokens', CRM_Utils_Token::formatTokensForDisplay($tokenProcessor->listTokens()));
+
+        return parent::run();
+    }
+}

--- a/templates/CRM/Civioffice/Page/Tokens.tpl
+++ b/templates/CRM/Civioffice/Page/Tokens.tpl
@@ -1,0 +1,40 @@
+{*-------------------------------------------------------+
+| SYSTOPIA CiviOffice Integration                        |
+| Copyright (C) 2022 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{crmScope extensionKey='de.systopia.civioffice'}
+  <div class="crm-section">
+    <div class="crm-content-block">
+      <div class="help">
+          {ts}This page lists all tokens CiviOffice is potentially able to replace in documents, however, this depends on the context. E.g. contribution tokens are only available in a context of generating documents for particular contributions, whereas general tokens, such as for domain or date, are always available.{/ts}
+      </div>
+        {if !empty($tokens)}
+            {foreach from=$tokens item=group}
+              <details class="panel">
+                <summary class="panel-heading">{$group.text}</summary>
+                <table class="panel-body">
+                    {foreach from=$group.children item=token}
+                      <tr>
+                        <td>{$token.text}</td>
+                        <td>
+                          <pre>{$token.id}</pre>
+                        </td>
+                      </tr>
+                    {/foreach}
+                </table>
+              </details>
+            {/foreach}
+        {/if}
+    </div>
+  </div>
+{/crmScope}

--- a/xml/Menu/civioffice.xml
+++ b/xml/Menu/civioffice.xml
@@ -51,4 +51,10 @@
     <title>DocumentFromSingleContact</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/civioffice/tokens</path>
+    <page_callback>CRM_Civioffice_Page_Tokens</page_callback>
+    <title>Tokens</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This adds a CiviCRM page with a grouped list of tokens CiviOffice can potentially replace, including all entity contexts (currently contact, contribution, participant).