### PR TITLE
Change suggested and initial paths

### DIFF
--- a/CRM/Civioffice/DocumentRendererType/LocalUnoconv.php
+++ b/CRM/Civioffice/DocumentRendererType/LocalUnoconv.php
@@ -640,7 +640,7 @@ class CRM_Civioffice_DocumentRendererType_LocalUnoconv extends CRM_Civioffice_Do
     {
         return [
             'unoconv_binary_path' => '/usr/bin/unoconv',
-            'unoconv_lock_file_path' => '/var/www/unoconv.lock',
+            'unoconv_lock_file_path' => CRM_Civioffice_Configuration::getHomeFolder() . '/unoconv.lock',
             'prepare_docx' => false,
             'phpword_tokens' => false,
         ];

--- a/CRM/Civioffice/DocumentStore/LocalTemp.php
+++ b/CRM/Civioffice/DocumentStore/LocalTemp.php
@@ -36,7 +36,7 @@ class CRM_Civioffice_DocumentStore_LocalTemp extends CRM_Civioffice_DocumentStor
                 unlink($temp_folder_path);
                 Civi::log()->debug("CiviOffice: Temp folder already exists. Deleting and trying to create a new one");
             }
-            mkdir($temp_folder_path);
+            mkdir($temp_folder_path, 0777, true);
         }
         parent::__construct("tmp::{$temp_folder_path}", E::ts("Temporary Files"), false, false);
         $this->base_folder = $temp_folder_path;

--- a/CRM/Civioffice/Form/LocalDocumentStore/LocalDocumentStoreSettings.php
+++ b/CRM/Civioffice/Form/LocalDocumentStore/LocalDocumentStoreSettings.php
@@ -47,6 +47,8 @@ class CRM_Civioffice_Form_LocalDocumentStore_LocalDocumentStoreSettings extends 
                 'local_temp_folder' => Civi::settings()->get(CRM_Civioffice_DocumentStore_Local::LOCAL_TEMP_PATH_SETTINGS_KEY),
             ]
         );
+        $this->assign('local_folder_suggestion', Civi::paths()->getPath('[civicrm.files]/civioffice'));
+        $this->assign('local_temp_folder_suggestion', sys_get_temp_dir() . '/civioffice');
 
         $this->addButtons(
             [
@@ -72,31 +74,29 @@ class CRM_Civioffice_Form_LocalDocumentStore_LocalDocumentStoreSettings extends 
         // verify that the folder is 1) there, 2) readable
         if (!empty($this->_submitValues['local_folder'])) {
             $local_folder = $this->_submitValues['local_folder'];
-            if (!is_dir($local_folder)) {
+            if (!file_exists($local_folder) && !mkdir($local_folder, 0777, true)) {
+              $this->_errors['local_folder'] = E::ts('Could not create directory');
+            } else if (!is_dir($local_folder)) {
                 $this->_errors['local_folder'] = E::ts("This is not a folder");
-            } else {
-                if (!is_readable($local_folder)) {
-                    $this->_errors['local_folder'] = E::ts("This folder cannot be accessed");
-                }
+            } else if (!is_readable($local_folder)) {
+                $this->_errors['local_folder'] = E::ts("This folder cannot be accessed");
             }
         }
 
         if (!empty($this->_submitValues['local_temp_folder'])) {
             $local_temp_folder = $this->_submitValues['local_temp_folder'];
-            if (!is_dir($local_temp_folder)) {
+            if (!file_exists($local_temp_folder) && !mkdir($local_folder, 0777, true)) {
+              $this->_errors['local_temp_folder'] = E::ts('Could not create directory');
+            } else if (!is_dir($local_temp_folder)) {
                 $this->_errors['local_temp_folder'] = E::ts("This is not a folder");
-            } else {
-                if (!is_readable($local_temp_folder)) {
-                    $this->_errors['local_temp_folder'] = E::ts("This folder cannot be accessed");
-                }
+            } else if (!is_readable($local_temp_folder)) {
+                $this->_errors['local_temp_folder'] = E::ts("This folder cannot be accessed");
             }
         }
 
         return (0 == count($this->_errors));
     }
 
-
-  
     public function postProcess()
     {
         $values = $this->exportValues();

--- a/CRM/Civioffice/Upgrader.php
+++ b/CRM/Civioffice/Upgrader.php
@@ -12,6 +12,11 @@ class CRM_Civioffice_Upgrader extends CRM_Extension_Upgrader_Base
      */
     public function install()
     {
+        Civi::settings()->set(
+            CRM_Civioffice_DocumentStore_Local::LOCAL_TEMP_PATH_SETTINGS_KEY,
+            sys_get_temp_dir() . '/civioffice'
+        );
+
         // Create/synchronise the Live Snippets option group.
         $customData = new CRM_Civioffice_CustomData(E::LONG_NAME);
         $customData->syncOptionGroup(E::path('resources/live_snippets_option_group.json'));

--- a/templates/CRM/Civioffice/Form/LocalDocumentStore/LocalDocumentStoreSettings.tpl
+++ b/templates/CRM/Civioffice/Form/LocalDocumentStore/LocalDocumentStoreSettings.tpl
@@ -15,14 +15,14 @@
 {crmScope extensionKey='de.systopia.civioffice'}
 
 <div class="crm-section">
-  <div class="help">{ts}Path to storage folder.<br>For example: <code>/var/civioffice/previous_documents</code>{/ts}</div>
+  <div class="help">{ts}Path to storage folder.<br>For example: <code>{$local_folder_suggestion}</code>{/ts}</div>
   <div class="label">{$form.local_folder.label}</div>
   <div class="content">{$form.local_folder.html}</div>
   <div class="clear"></div>
 </div>
 
 <div class="crm-section">
-  <div class="help">{ts}Path to temporary folder.<br>For example: <code>/path/to/civicrm/files/templates_c/civioffice/temp</code>{/ts}</div>
+  <div class="help">{ts}Path to temporary folder.<br>For example: <code>{$local_temp_folder_suggestion}</code>{/ts}</div>
   <div class="label">{$form.local_temp_folder.label}</div>
   <div class="content">{$form.local_temp_folder.html}</div>
   <div class="clear"></div>


### PR DESCRIPTION
- Default path for unoconv.lock: `CRM_Civioffice_Configuration::getHomeFolder() . '/unoconv.lock`
- Initial and suggested local temp path: `sys_get_temp_dir() . '/civioffice`
- Suggested local path: `Civi::paths()->getPath('[civicrm.files]/civioffice')`

systopia-reference: 20217