### PR TITLE
Use "w+" mode for opening/creating the unoconv lock file

### DIFF
--- a/CRM/Civioffice/DocumentRendererType/LocalUnoconv.php
+++ b/CRM/Civioffice/DocumentRendererType/LocalUnoconv.php
@@ -605,7 +605,7 @@ class CRM_Civioffice_DocumentRendererType_LocalUnoconv extends CRM_Civioffice_Do
     {
         $lock_file_path = $this->unoconv_lock_file_path;
         if ($lock_file_path) {
-            $this->unoconv_lock_file = fopen($lock_file_path, "r+");
+            $this->unoconv_lock_file = fopen($lock_file_path, "w+");
             if (!flock($this->unoconv_lock_file, LOCK_EX)) {
                 throw new Exception(E::ts("CiviOffice: Could not acquire unoconv lock."));
             }

--- a/templates/CRM/Civioffice/Form/DocumentRenderer/Settings/LocalUnoconv.tpl
+++ b/templates/CRM/Civioffice/Form/DocumentRenderer/Settings/LocalUnoconv.tpl
@@ -22,7 +22,7 @@
   </div>
 
   <div class="crm-section">
-    <div class="help">{ts}We strongly recommend creating a system-wide lock file on this server to synchronise access. (It may only run one unoconv process at the same time.) You can create such a file doing this in the server console:<br><code>touch /some/accessible/path/unoconv.lock && chmod 777 /some/accessible/path/unoconv.lock</code><br>Please note: This path needs to be equal in every civicrm environment on this server. Otherwise, locking is only active for this very civicrm instance!{/ts}</div>
+    <div class="help">{ts}We strongly recommend creating a system-wide lock file on this server to synchronise access. (It may only run one unoconv process at the same time.) Such a file is created automatically at the location shown below. Please note: This path needs to be equal in every civicrm environment on this server. Otherwise, locking is only active for this very civicrm instance!{/ts}</div>
     <div class="label">{$form.unoconv_lock_file_path.label}</div>
     <div class="content">{$form.unoconv_lock_file_path.html}</div>
     <div class="clear"></div>


### PR DESCRIPTION
If I understand correctly, attempting a file lock for the *unoconv* lock file should create it if it doesn't exist. However, `fopen()` uses `r+` which doesn't create the file if it's missing.

*systopia-reference: 23962*