### PR TITLE
Persist change of renderer name

### DIFF
--- a/CRM/Civioffice/Form/DocumentRenderer/Settings.php
+++ b/CRM/Civioffice/Form/DocumentRenderer/Settings.php
@@ -158,6 +158,9 @@ class CRM_Civioffice_Form_DocumentRenderer_Settings extends CRM_Core_Form {
                   ]
               );
           }
+          else {
+            $this->documentRenderer->setName($values['name']);
+          }
 
           $this->documentRendererType->postProcessSettingsForm($this);
 

--- a/CRM/Civioffice/OfficeComponent.php
+++ b/CRM/Civioffice/OfficeComponent.php
@@ -83,6 +83,11 @@ abstract class CRM_Civioffice_OfficeComponent
         return $this->name;
     }
 
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
     /**
      * Get the (localised) component description
      *


### PR DESCRIPTION
The renderer settings form allows to enter a new name. Though the field value was not used then.