### PR TITLE
MimeType: Fix extension check

### DIFF
--- a/CRM/Civioffice/MimeType.php
+++ b/CRM/Civioffice/MimeType.php
@@ -67,6 +67,6 @@ abstract class CRM_Civioffice_MimeType
     {
         $extension = self::mapMimeTypeToFileExtension($mime_type);
 
-        return (bool)preg_match("#\w+\.{$extension}$#", $file_name);
+        return pathinfo($file_name, PATHINFO_EXTENSION) === $extension;
     }
 }


### PR DESCRIPTION
Fixes #21.

The regex used previously required one word character before the `.`, i.e. for example a `)` at that position made the check to always return `FALSE` independently of the actual file name extension.