### PR TITLE
Register event subscribers as services

### DIFF
--- a/civioffice.php
+++ b/civioffice.php
@@ -111,14 +111,6 @@ function civioffice_civicrm_config(&$config)
 {
     _civioffice_composer_autoload();
     _civioffice_civix_civicrm_config($config);
-
-    \Civi::dispatcher()->addSubscriber(new CRM_Civioffice_Tokens('civioffice'));
-
-    if (interface_exists('\Civi\Mailattachment\AttachmentType\AttachmentTypeInterface')) {
-        \Civi::dispatcher()->addSubscriber(new CRM_Civioffice_AttachmentProvider());
-    }
-
-    Civi::dispatcher()->addSubscriber(new CRM_Civioffice_Configuration());
 }
 
 /**

--- a/services/civioffice.php
+++ b/services/civioffice.php
@@ -49,6 +49,20 @@ $container->autowire(RenderWebAction::class)
   ->setPublic(TRUE)
   ->setShared(TRUE);
 
+$container->register(\CRM_Civioffice_Tokens::class, \CRM_Civioffice_Tokens::class)
+  ->setArgument('$entity', 'civioffice')
+  ->addTag('kernel.event_subscriber')
+  ->setLazy(TRUE);
+
+$container->register(\CRM_Civioffice_Configuration::class, \CRM_Civioffice_Configuration::class)
+  ->setFactory([\CRM_Civioffice_Configuration::class, 'getConfig'])
+  ->addTag('kernel.event_subscriber');
+
+if (interface_exists('\Civi\Mailattachment\AttachmentType\AttachmentTypeInterface')) {
+  $container->register(\CRM_Civioffice_AttachmentProvider::class, \CRM_Civioffice_AttachmentProvider::class)
+    ->addTag('kernel.event_subscriber');
+}
+
 $container->autowire(CiviOfficeSearchKitTaskSubscriber::class)
   ->addTag('kernel.event_subscriber');
 


### PR DESCRIPTION
Previously some subscribers where initialized and added to the event dispatcher in `hook_civicrm_config()`.

`CRM_Civioffice_Tokens` is marked as lazy so this fixes #59.