### PR TITLE
Prevent infinite loop when tokens are used in headers or footers

### DIFF
--- a/CRM/Civioffice/DocumentRendererType/LocalUnoconv/PhpWordTemplateProcessor.php
+++ b/CRM/Civioffice/DocumentRendererType/LocalUnoconv/PhpWordTemplateProcessor.php
@@ -104,20 +104,21 @@ class CRM_Civioffice_DocumentRendererType_LocalUnoconv_PhpWordTemplateProcessor 
       // styles.
       PhpWord\Shared\Html::addHtml($section, $renderedTokenMessage);
       $elements = $section->getElements();
-      // setValue() and setElementsValue() replace only the first occurrence of macro variables in the document, so loop
-      // until all have been replaced.
-      do {
-        if ([] === $elements) {
-          // Note: If the paragraph had the macro as its only content, it
-          // will not be removed (i.e. leave an empty paragraph).
-          $this->setValue($macroVariable, '');
-        }
-        else {
+      if ([] === $elements) {
+        // Note: If the paragraph had the macro as its only content, it
+        // will not be removed (i.e. leave an empty paragraph).
+        $this->setValue($macroVariable, '');
+      }
+      else {
+        // setElementsValue() replace only the first occurrence of macro variables in the document, so loop
+        // until all have been replaced.
+        // @todo Replace not only macros in the main part, but also in headers and footers.
+        do {
           // ... or as HTML: Render all elements and insert in the text
           // run or paragraph containing the macro.
           $this->setElementsValue($macroVariable, $elements, TRUE);
-        }
-      } while (in_array($macroVariable, $this->getVariables(), TRUE));
+        } while (in_array($macroVariable, $this->getVariablesForPart($this->tempDocumentMainPart), TRUE));
+      }
     }
     catch (Exception $exception) {
       throw new CRM_Core_Exception(


### PR DESCRIPTION
Fixes #71.

Note: `setValue()` replaces all variables in the document since 0.13.0 (https://github.com/PHPOffice/PHPWord/issues/618) so it's not necessary to execute it in a loop.

I'll add another issue regarding replacement of variables in footers and headers.

systopia-reference: 27046