### PR TITLE
Remove unoconv check in validateform because it will always fail on servers with open_basedir restrictions in place

### DIFF
--- a/CRM/Civioffice/DocumentRendererType/LocalUnoconv.php
+++ b/CRM/Civioffice/DocumentRendererType/LocalUnoconv.php
@@ -213,9 +213,10 @@ class CRM_Civioffice_DocumentRendererType_LocalUnoconv extends CRM_Civioffice_Do
         $unoconv_binary_path = $form->_submitValues['unoconv_binary_path'];
         $unoconv_lock_file_path = $form->_submitValues['unoconv_lock_file_path'];
 
-        if (!file_exists($unoconv_binary_path)) {
-            $form->_errors['unoconv_binary_path'] = E::ts("File does not exist. Please provide a correct filename.");
-        }
+        // There used to be a file_exists() check here for validating that the unoconv binary exists in the given path.
+        // We can't however check eg. /usr/bin/unoconv on a site with open_basedir restrictions in place as this check
+        // would always fail. There is a check running `unoconv --version` in the isReady() method() which implicitly
+        // covers the validation of the unconv binary being accessible.
 
         if (!empty($lockfile_to_check)) {
             if (!file_exists($unoconv_lock_file_path)) {


### PR DESCRIPTION
file_exists() and other similar functions will always fail on eg. /usr/bin/unoconv because it is not allowed to access system files when open_basedir restrictions are in place.