### PR TITLE
Define setting data type correctly for "civioffice_renderers" setting

### DIFF
--- a/settings/civioffice.setting.php
+++ b/settings/civioffice.setting.php
@@ -13,22 +13,23 @@
 | written permission from the original author(s).        |
 +-------------------------------------------------------*/
 
+declare(strict_types = 1);
+
 use CRM_Civioffice_ExtensionUtil as E;
 
 return [
-    'civioffice_renderers' => [
-        'name' => 'civioffice_renderers',
-        'type' => 'String',
-        'serialize' => CRM_Core_DAO::SERIALIZE_JSON,
-        'is_domain' => 1,
-        'description' => E::ts('CiviOffice renderers.'),
-        'default' => [],
-        'title' => E::ts('CiviOffice Renderers'),
-        'help_text' => '',
-        'html_type' => 'select',
-        'html_attributes' => [
-            'class' => 'crm-select2',
-            'multiple' => 1,
-        ],
+  'civioffice_renderers' => [
+    'name' => 'civioffice_renderers',
+    'type' => 'Array',
+    'is_domain' => 1,
+    'description' => E::ts('CiviOffice renderers.'),
+    'default' => [],
+    'title' => E::ts('CiviOffice Renderers'),
+    'help_text' => '',
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+      'multiple' => 1,
     ],
+  ],
 ];


### PR DESCRIPTION
The `civioffice_renderers` setting is an array, but its metadata defined it as `String` with a JSON-serialization, which is not correct for settings.

This seemed to have caused errors like
```
In DAO.php line 3388:
                                                                       
  strlen(): Argument #1 ($string) must be of type string, array given  
```
when retrieving (any) settings.

*systopia-reference: 26585*