### PR TITLE
Upload form: Prepare TabHeader tabs for changed core template

### DIFF
--- a/CRM/Civioffice/Form/DocumentUpload/TabHeader.php
+++ b/CRM/Civioffice/Form/DocumentUpload/TabHeader.php
@@ -32,6 +32,9 @@ class CRM_Civioffice_Form_DocumentUpload_TabHeader {
       $tabs = self::process($form);
       $form->set('tabHeader', $tabs);
     }
+    if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
+      $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
+    }
     $form->assign_by_ref('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile(


### PR DESCRIPTION
civicrm/civicrm-core#31697 changed the `TabHeader.tpl` smarty template to require `url` keys for tabs instead of `link`.

The CiviOffice upload form uses core's `TabHeader.tpl` and needs to be adjusted for this core refactoring. This is being done by using the `\CRM_Core_Smarty::setRequiredTabTemplateKeys()` method added in civicrm/civicrm-core#31636 before assigning the template variable.

Without this change, tab panels are not being loaded at all starting with CiviCRM `5.82.0`.