### PR TITLE
Fix calling deprecated method `\CRM_Core_Form::assign_by_ref()`

### DIFF
--- a/CRM/Civioffice/Form/DocumentUpload/TabHeader.php
+++ b/CRM/Civioffice/Form/DocumentUpload/TabHeader.php
@@ -35,7 +35,7 @@ class CRM_Civioffice_Form_DocumentUpload_TabHeader {
     if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
       $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     }
-    $form->assign_by_ref('tabHeader', $tabs);
+    $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile(
         'civicrm',
@@ -44,10 +44,10 @@ class CRM_Civioffice_Form_DocumentUpload_TabHeader {
         'html-header'
       )
       ->addSetting([
-                     'tabSettings' => [
-                       'active' => self::getCurrentTab($tabs),
-                     ],
-                   ]);
+        'tabSettings' => [
+          'active' => self::getCurrentTab($tabs),
+        ],
+      ]);
     return $tabs;
   }
 
@@ -66,24 +66,24 @@ class CRM_Civioffice_Form_DocumentUpload_TabHeader {
       'icon' => FALSE,
     ];
 
-      $tabs = [
-          'private' => [
-                  'title' => E::ts('My Documents'),
-                  'link' => CRM_Utils_System::url(
-                      'civicrm/civioffice/document_upload',
-                      "common=0"
-                  ),
-                  'icon' => 'crm-i fa-user',
-              ] + $default,
-          'shared' => [
-                  'title' => E::ts('Shared Documents'),
-                  'link' => CRM_Utils_System::url(
-                      'civicrm/civioffice/document_upload',
-                      "common=1"
-                  ),
-                  'icon' => 'crm-i fa-users',
-              ] + $default,
-      ];
+    $tabs = [
+      'private' => [
+        'title' => E::ts('My Documents'),
+        'link' => CRM_Utils_System::url(
+          'civicrm/civioffice/document_upload',
+          'common=0'
+        ),
+        'icon' => 'crm-i fa-user',
+      ] + $default,
+      'shared' => [
+        'title' => E::ts('Shared Documents'),
+        'link' => CRM_Utils_System::url(
+          'civicrm/civioffice/document_upload',
+          'common=1'
+        ),
+        'icon' => 'crm-i fa-users',
+      ] + $default,
+    ];
 
     // Load requested tab.
     $current = CRM_Utils_Request::retrieve(


### PR DESCRIPTION
https://github.com/civicrm/civicrm-core/blob/a81702cf2f71a7ffd8b62f45f9d2e00439a8efd3/CRM/Core/Form.php#L1427

> `@deprecated since 5.72 will be removed around 5.84`