### PR TITLE
`trim()` paths in local store configuration

### DIFF
--- a/CRM/Civioffice/DocumentStore/Local.php
+++ b/CRM/Civioffice/DocumentStore/Local.php
@@ -18,32 +18,52 @@ use CRM_Civioffice_ExtensionUtil as E;
 /**
  * Document store based on a local folder
  */
-class CRM_Civioffice_DocumentStore_Local extends CRM_Civioffice_DocumentStore
-{
-    const LOCAL_STATIC_PATH_SETTINGS_KEY = 'civioffice_store_local_static_path';
-    const LOCAL_TEMP_PATH_SETTINGS_KEY = 'civioffice_store_local_temp_path';
+class CRM_Civioffice_DocumentStore_Local extends CRM_Civioffice_DocumentStore {
 
-    /** @var string local folder this store has access to */
-    protected $base_folder;
+  public const LOCAL_STATIC_PATH_SETTINGS_KEY = 'civioffice_store_local_static_path';
 
-    /** @var string local folder this store has access to */
-    protected $temp_folder;
+  public const LOCAL_TEMP_PATH_SETTINGS_KEY = 'civioffice_store_local_temp_path';
 
-    /** @var boolean should this be readable */
-    protected $readonly;
+  /**
+   * Local folder this store has access to.
+   */
+  protected ?string $base_folder;
 
-    /** @var boolean should there be subfolders? */
-    protected $has_subfolders;
+  /**
+   * Local folder this store has access to.
+   */
+  protected ?string $temp_folder;
 
-    public function __construct($uri, $name, $readonly, $has_subfolders)
-    {
-        parent::__construct($uri, $name);
-        $this->base_folder = Civi::settings()->get(self::LOCAL_STATIC_PATH_SETTINGS_KEY);
-        $this->temp_folder = Civi::settings()->get(self::LOCAL_TEMP_PATH_SETTINGS_KEY);
-        $this->readonly = $readonly;
-        $this->has_subfolders = $has_subfolders;
-    }
+  /**
+   * Whether this should only be readable.
+   */
+  protected bool $readonly;
 
+  /**
+   * Whether there should be subfolders.
+   */
+  protected bool $has_subfolders;
+
+  /**
+   * @phpstan-param string $uri
+   * @phpstan-param string $name
+   */
+  public function __construct($uri, $name, bool $readonly, bool $has_subfolders) {
+    parent::__construct($uri, $name);
+
+    /** @phpstan-var string|null $baseFolder */
+    $baseFolder = Civi::settings()->get(self::LOCAL_STATIC_PATH_SETTINGS_KEY);
+    // TODO: trim() existing config value in an upgrade step and do not trim() here.
+    $this->base_folder = is_string($baseFolder) ? trim($baseFolder) : NULL;
+
+    /** @phpstan-var string|null $tempFolder */
+    $tempFolder = Civi::settings()->get(self::LOCAL_TEMP_PATH_SETTINGS_KEY);
+    // TODO: trim() existing config value in an upgrade step and do not trim() here.
+    $this->temp_folder = is_string($tempFolder) ? trim($tempFolder) : NULL;
+
+    $this->readonly = $readonly;
+    $this->has_subfolders = $has_subfolders;
+  }
 
     /**
      * Get a list of available documents

--- a/CRM/Civioffice/Form/LocalDocumentStore/LocalDocumentStoreSettings.php
+++ b/CRM/Civioffice/Form/LocalDocumentStore/LocalDocumentStoreSettings.php
@@ -63,47 +63,55 @@ class CRM_Civioffice_Form_LocalDocumentStore_LocalDocumentStoreSettings extends 
         parent::buildQuickForm();
     }
 
-    /**
-     * Validate input data
-     * @return bool
-     */
-    public function validate(): bool
-    {
-        parent::validate();
+  /**
+   * Validate input data
+   *
+   * @return bool
+   */
+  public function validate(): bool {
+    parent::validate();
 
-        // verify that the folder is 1) there, 2) readable
-        if (!empty($this->_submitValues['local_folder'])) {
-            $local_folder = $this->_submitValues['local_folder'];
-            if (!file_exists($local_folder) && !mkdir($local_folder, 0777, true)) {
-              $this->_errors['local_folder'] = E::ts('Could not create directory');
-            } else if (!is_dir($local_folder)) {
-                $this->_errors['local_folder'] = E::ts("This is not a folder");
-            } else if (!is_readable($local_folder)) {
-                $this->_errors['local_folder'] = E::ts("This folder cannot be accessed");
-            }
+    // verify that the folder is 1) there, 2) readable
+    $local_folder = trim($this->_submitValues['local_folder']);
+    if ('' !== $local_folder) {
+      if (!file_exists($local_folder) && !mkdir($local_folder, 0777, TRUE)) {
+        $this->_errors['local_folder'] = E::ts('Could not create directory');
+      }
+      else {
+        if (!is_dir($local_folder)) {
+          $this->_errors['local_folder'] = E::ts('This is not a folder');
         }
-
-        if (!empty($this->_submitValues['local_temp_folder'])) {
-            $local_temp_folder = $this->_submitValues['local_temp_folder'];
-            if (!file_exists($local_temp_folder) && !mkdir($local_temp_folder, 0777, true)) {
-              $this->_errors['local_temp_folder'] = E::ts('Could not create directory');
-            } else if (!is_dir($local_temp_folder)) {
-                $this->_errors['local_temp_folder'] = E::ts("This is not a folder");
-            } else if (!is_readable($local_temp_folder)) {
-                $this->_errors['local_temp_folder'] = E::ts("This folder cannot be accessed");
-            }
+        elseif (!is_readable($local_folder)) {
+          $this->_errors['local_folder'] = E::ts('This folder cannot be accessed');
         }
-
-        return (0 == count($this->_errors));
+      }
     }
 
-    public function postProcess()
-    {
-        $values = $this->exportValues();
-
-        // store
-        Civi::settings()->set(CRM_Civioffice_DocumentStore_Local::LOCAL_STATIC_PATH_SETTINGS_KEY, $values['local_folder']);
-        Civi::settings()->set(CRM_Civioffice_DocumentStore_Local::LOCAL_TEMP_PATH_SETTINGS_KEY, $values['local_temp_folder']);
+    $local_temp_folder = trim($this->_submitValues['local_temp_folder']);
+    if ('' !== $local_temp_folder) {
+      if (!file_exists($local_temp_folder) && !mkdir($local_temp_folder, 0777, TRUE)) {
+        $this->_errors['local_temp_folder'] = E::ts('Could not create directory');
+      }
+      else {
+        if (!is_dir($local_temp_folder)) {
+          $this->_errors['local_temp_folder'] = E::ts('This is not a folder');
+        }
+        elseif (!is_readable($local_temp_folder)) {
+          $this->_errors['local_temp_folder'] = E::ts('This folder cannot be accessed');
+        }
+      }
     }
+
+    return 0 === count($this->_errors);
+  }
+
+  public function postProcess(): void {
+    $values = $this->exportValues();
+
+    // store
+    Civi::settings()
+      ->set(CRM_Civioffice_DocumentStore_Local::LOCAL_STATIC_PATH_SETTINGS_KEY, trim($values['local_folder']))
+      ->set(CRM_Civioffice_DocumentStore_Local::LOCAL_TEMP_PATH_SETTINGS_KEY, trim($values['local_temp_folder']));
+  }
 
 }

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -9,5 +9,6 @@ parameters:
 		- {VENDOR_DIR}/civicrm/civicrm-core/api/
 		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
 		- {VENDOR_DIR}/civicrm/civicrm-core/ext/
+		- {VENDOR_DIR}/civicrm/civicrm-packages/HTML/
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php


### PR DESCRIPTION
Fixes #77.

This `trim()`s paths in the local document store's configuration before saving them, and once again when using them (for paths with whitespace already present in the config). Existing (default) values in the config form are not being trimmed.

*systopia-reference: 27681*