### PR TITLE
Fix replacing line breaks

### DIFF
--- a/Civi/Civioffice/PhpWord/PhpWordTemplateProcessor.php
+++ b/Civi/Civioffice/PhpWord/PhpWordTemplateProcessor.php
@@ -153,7 +153,8 @@ class PhpWordTemplateProcessor extends PhpWord\TemplateProcessor {
       $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
 
       // For inline elements, do not create a new paragraph.
-      $withParagraph = \PhpOffice\PhpWord\Writer\Word2007\Element\Text::class !== $objectClass;
+      $withParagraph = !is_a($objectClass, \PhpOffice\PhpWord\Writer\Word2007\Element\Text::class, TRUE)
+        || is_a($objectClass, \PhpOffice\PhpWord\Writer\Word2007\Element\TextRun::class, TRUE);
       $hasParagraphs = $hasParagraphs || $withParagraph;
 
       $xmlWriter = new PhpWord\Shared\XMLWriter();

--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -196,22 +196,22 @@ EOD;
 
   public function testReplaceLineBreak(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+    EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();

--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -194,6 +194,69 @@ EOD;
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
+  public function testReplaceLineBreak(): void {
+    $mainPart = <<<EOD
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Normal"/>
+      </w:pPr>
+      <w:r>
+        <w:rPr>
+          <w:b w:val="true"/>
+        </w:rPr>
+        <w:t>Foo {place.holder} bar</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>
+EOD;
+
+    $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
+    $templateProcessor->civiTokensToMacros();
+    $templateProcessor->replaceHtmlToken('place.holder', 'test<br/>123');
+
+    $expectedMainPart = <<<EOD
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Normal"/>
+      </w:pPr>
+      <w:r>
+        <w:rPr>
+          <w:b w:val="true"/>
+        </w:rPr>
+        <w:t xml:space="preserve">Foo </w:t>
+      </w:r>
+      <w:r>
+        <w:rPr>
+          <w:b w:val="true"/>
+        </w:rPr>
+        <w:t xml:space="preserve">test</w:t>
+      </w:r>
+      <w:br/>
+      <w:r>
+        <w:rPr>
+          <w:b w:val="true"/>
+        </w:rPr>
+        <w:t xml:space="preserve">123</w:t>
+      </w:r>
+      <w:r>
+        <w:rPr>
+          <w:b w:val="true"/>
+        </w:rPr>
+        <w:t xml:space="preserve"> bar</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>
+EOD;
+
+    static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
+  }
+
   /**
    * When a token is replaced with a paragraph, property tags (pPr, rRr) should
    * be copied into each paragraph/text run.

--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -28,168 +28,168 @@ final class PhpWordTemplateProcessorTest extends TestCase {
 
   public function testReplaceSimple(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', 'test 123');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-       <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+             <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
   public function testReplaceSpan(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<span>test 123</span>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
   public function testReplaceSpanMultiple(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder}</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<span>test</span><span> 123</span>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve"> 123</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> 123</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -211,48 +211,48 @@ EOD;
           </w:p>
         </w:body>
       </w:document>
-    EOD;
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', 'test<br/>123');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test</w:t>
-      </w:r>
-      <w:br/>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">123</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test</w:t>
+            </w:r>
+            <w:br/>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">123</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -274,7 +274,7 @@ EOD;
           </w:p>
         </w:body>
       </w:document>
-    EOD;
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
@@ -325,7 +325,7 @@ EOD;
           </w:p>
         </w:body>
       </w:document>
-    EOD;
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -336,66 +336,66 @@ EOD;
    */
   public function testReplaceParagraphEnclosed(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<p>test 123</p>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-    </w:p>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-    </w:p>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -409,55 +409,55 @@ EOD;
    */
   public function testReplaceParagraphStart(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>{place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>{place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<p>test 123</p>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-    </w:p>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -471,116 +471,116 @@ EOD;
    */
   public function testReplaceParagraphEnd(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder}</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<p>test 123</p>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-    </w:p>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
   public function testStrong(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<strong>bold</strong>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="1"/>
-          <w:bCs w:val="1"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t xml:space="preserve">bold</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="1"/>
+                <w:bCs w:val="1"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t xml:space="preserve">bold</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -591,64 +591,64 @@ EOD;
    */
   public function testReplaceParagraphWithTextRunStyle(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-        <w:rPr>
-          <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
-        </w:rPr>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder}</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+              <w:rPr>
+                <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
+              </w:rPr>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<p>test 123</p>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-        <w:rPr>
-          <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
-        </w:rPr>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-    </w:p>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-        <w:rPr>
-          <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
-        </w:rPr>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+              <w:rPr>
+                <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
+              </w:rPr>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+              <w:rPr>
+                <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
+              </w:rPr>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
@@ -660,180 +660,180 @@ EOD;
    */
   public function testReplaceParagraphWithRunStyleAndStrong(): void {
     $mainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-        <w:rPr>
-          <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
-        </w:rPr>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t>Foo {place.holder}</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+              <w:rPr>
+                <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
+              </w:rPr>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', '<p><strong>test 123</strong></p>');
 
     $expectedMainPart = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-        <w:rPr>
-          <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
-        </w:rPr>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-    </w:p>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-        <w:rPr>
-          <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
-        </w:rPr>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="1"/>
-          <w:bCs w:val="1"/>
-          <w:color w:val="FF0000"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+              <w:rPr>
+                <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
+              </w:rPr>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+              <w:rPr>
+                <w:rFonts w:ascii="Liberation Sans" w:hAnsi="Liberation Sans"/>
+              </w:rPr>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="1"/>
+                <w:bCs w:val="1"/>
+                <w:color w:val="FF0000"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
   public function testReplaceInHeader(): void {
     $header = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor('', [$header]);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', 'test 123');
 
     $expectedHeader = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-       <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+             <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedHeader, $templateProcessor->getHeaders()[0]);
   }
 
   public function testReplaceInFooter(): void {
     $footer = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t>Foo {place.holder} bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     $templateProcessor = new TestablePhpWordTemplateProcessor('', [], [$footer]);
     $templateProcessor->civiTokensToMacros();
     $templateProcessor->replaceHtmlToken('place.holder', 'test 123');
 
     $expectedFooter = <<<EOD
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="Normal"/>
-      </w:pPr>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">Foo </w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-        <w:t xml:space="preserve">test 123</w:t>
-      </w:r>
-      <w:r>
-        <w:rPr>
-          <w:b w:val="true"/>
-        </w:rPr>
-       <w:t xml:space="preserve"> bar</w:t>
-      </w:r>
-    </w:p>
-  </w:body>
-</w:document>
-EOD;
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+             <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
 
     static::assertXmlStringEqualsXmlString($expectedFooter, $templateProcessor->getFooters()[0]);
   }


### PR DESCRIPTION
`<br/>` is now replaced by `<w:br/>` instead of `<w:p/>`.

The example in the new test (`test<br/>123`) previously resulted in a document where nothing was visible at the place of the placeholder.

This might also fixes other inline elements because the detection is now more generic.

systopia-reference: 27681