### PR TITLE
Use regular expressions with negative lookahead when matching XML tags

### DIFF
--- a/Civi/Civioffice/PhpWord/Util/TemplateUtil.php
+++ b/Civi/Civioffice/PhpWord/Util/TemplateUtil.php
@@ -131,11 +131,11 @@ final class TemplateUtil {
     }
 
     $matches = [];
-    preg_match('#<w:pPr.*</w:pPr>#i', $paragraph, $matches);
+    preg_match('#<w:pPr(?:(?!<w:pPr).)*</w:pPr>#', $paragraph, $matches);
     $extractedParagraphStyle = $matches[0] ?? '';
 
-    // <w:pPr> may contain <w:rPr> itself so we have to match for <w:rPr> inside of <w:r>
-    preg_match('#<w:r>.*(<w:rPr.*</w:rPr>).*</w:r>#i', $paragraph, $matches);
+    // <w:pPr> may contain <w:rPr> itself so we have to match for <w:rPr> inside <w:r>
+    preg_match('#<w:r>(?:(?!<w:r>).)*(<w:rPr(?:(?!<w:rPr).)*</w:rPr>)(?:(?!<w:r>).)*</w:r>#', $paragraph, $matches);
     $extractedTextRunStyle = $matches[1] ?? '';
 
     $result = str_replace(

--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -257,6 +257,79 @@ EOD;
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
+  public function testReplaceParagraphWithLineBreak(): void {
+    $mainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+    EOD;
+
+    $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
+    $templateProcessor->civiTokensToMacros();
+    $templateProcessor->replaceHtmlToken('place.holder', '<p>test<br/>123</p>');
+
+    $expectedMainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test</w:t>
+            </w:r>
+            <w:br/>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">123</w:t>
+            </w:r>
+          </w:p>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+    EOD;
+
+    static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
+  }
+
   /**
    * When a token is replaced with a paragraph, property tags (pPr, rRr) should
    * be copied into each paragraph/text run.


### PR DESCRIPTION
Previously the regular expressions didn't work correctly for strings containing the same tag multiple times like in
`<w:p><w:pPr/><w:r><w:rPr/><w:t>foo</w:t></w:r><w:br/><w:r><w:rPr/><w:t>bar</w:t></w:r></w:p>`

Fixes #94.

systopia-reference: 27681