### PR TITLE
Recognize split tokens

### DIFF
--- a/Civi/Civioffice/PhpWord/PhpWordTemplateProcessor.php
+++ b/Civi/Civioffice/PhpWord/PhpWordTemplateProcessor.php
@@ -31,6 +31,10 @@ class PhpWordTemplateProcessor extends PhpWord\TemplateProcessor {
    *   An array of CiviCRM tokens found in the document.
    */
   public function civiTokensToMacros(): array {
+    $this->tempDocumentHeaders = TemplateUtil::combineRuns($this->tempDocumentHeaders);
+    $this->tempDocumentMainPart = TemplateUtil::combineRuns($this->tempDocumentMainPart);
+    $this->tempDocumentFooters = TemplateUtil::combineRuns($this->tempDocumentFooters);
+
     $tokens = [];
     foreach (
       [

--- a/Civi/Civioffice/PhpWord/Util/TemplateUtil.php
+++ b/Civi/Civioffice/PhpWord/Util/TemplateUtil.php
@@ -89,6 +89,23 @@ final class TemplateUtil {
   }
 
   /**
+   * Combines runs (element r) that have no visible impact, but only provide
+   * identifiers used to track the editing session (attributes rsidDel, rsidRPr,
+   * and rsidR).
+   * See: https://ooxml.info/docs/17/17.3/17.3.2/17.3.2.25/#attributes
+   *
+   * @template T of string|array<string>
+   *
+   * @param T $xml
+   *
+   * @return T
+   */
+  public static function combineRuns($xml) {
+    // @phpstan-ignore return.type
+    return preg_replace('#</w:t>[\s]*</w:r>[\s]*<w:r(?: w:(?:rsidDel|rsidRPr|rsidR)="[^"]+")*>[\s]*<w:t>#', '', $xml);
+  }
+
+  /**
    * Replace an XML block surrounding a string with a new block. Only the first
    * block containing the search string is replaced.
    *

--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -82,6 +82,67 @@ final class PhpWordTemplateProcessorTest extends TestCase {
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
+  public function testReplaceWithSplitToken(): void {
+    // There's a run that splits the token, but doesn't have a visible impact.
+    // It only provides an rsidR. The token shall be detected nevertheless.
+    $mainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place</w:t>
+            </w:r>
+            <w:r w:rsidR="FEDCBA98">
+              <w:t>.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
+    $templateProcessor->civiTokensToMacros();
+    $templateProcessor->replaceHtmlToken('place.holder', 'test 123');
+
+    $expectedMainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Foo </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+             <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
+  }
+
   public function testReplaceSpan(): void {
     $mainPart = <<<EOD
       <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">

--- a/tests/phpunit/Civi/Civioffice/PhpWord/Util/TemplateUtilTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/Util/TemplateUtilTest.php
@@ -1,0 +1,181 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Civioffice\PhpWord\Util;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Civioffice\PhpWord\Util\TemplateUtil
+ */
+final class TemplateUtilTest extends TestCase {
+
+  /**
+   * @dataProvider provideCombineRunsXml
+   */
+  public function testCombineRuns(string $xml, string $expected): void {
+    static::assertSame($expected, TemplateUtil::combineRuns($xml));
+    static::assertSame([$expected], TemplateUtil::combineRuns([$xml]));
+  }
+
+  /**
+   * @phpstan-return iterable<array{string, string}>
+   */
+  public function provideCombineRunsXml(): iterable {
+    $expected = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r>
+              <w:t>holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      $expected,
+    ];
+
+    // With rsidDel attribute.
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r w:rsidDel="0123456F">
+              <w:t>holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      $expected,
+    ];
+
+    // With rsidRPr attribute.
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r w:rsidRPr="0123456F">
+              <w:t>holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      $expected,
+    ];
+
+    // With rsidR attribute.
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r w:rsidR="0123456F">
+              <w:t>holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      $expected,
+    ];
+
+    // Run with rPr element shall not be changed.
+    $xml = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="Normal"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r>
+              <w:pPr>
+                <w:i/>
+              </w:pPr>
+              <w:t>holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+    yield [$xml, $xml];
+  }
+
+}


### PR DESCRIPTION
There might be tokens that are split in two or more text runs that have no visual impact. Those have to be recognized nevertheless.

Fixes #64.

systopia-reference: 27681