### PR TITLE
Handle `xml:space` attribute when combining runs

### DIFF
--- a/Civi/Civioffice/PhpWord/Util/StringUtil.php
+++ b/Civi/Civioffice/PhpWord/Util/StringUtil.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Civioffice\PhpWord\Util;
+
+final class StringUtil {
+
+  public static function findPos(string $string, string $search, int $offset = 0): ?int {
+    if (self::isRegex($search)) {
+      preg_match($search, $string, $matches, PREG_OFFSET_CAPTURE, $offset);
+
+      return $matches[0][1] ?? NULL;
+    }
+
+    $pos = strpos($string, $search, $offset);
+
+    return $pos === FALSE ? NULL : $pos;
+  }
+
+  /**
+   * @return bool
+   *   TRUE if the given string starts and ends with the same
+   *   non-alphanumeric, non-backslash, non-whitespace character, e.g. "/abc/"
+   *   or "#^abc$#".
+   */
+  public static function isRegex(string $string): bool {
+    return preg_match('/^(?<delim>[^a-zA-Z0-9\\\s]).*\k<delim>$/', $string) === 1;
+  }
+
+}

--- a/Civi/Civioffice/PhpWord/Util/XmlUtil.php
+++ b/Civi/Civioffice/PhpWord/Util/XmlUtil.php
@@ -95,6 +95,9 @@ final class XmlUtil {
    *
    * Note that only the first instance of the search string will be found
    *
+   * @param string $search
+   *   Treated as regular expression if it starts and ends with the same
+   *   delimiter.
    * @param string $blockType XML tag for block
    *
    * @return false|array{start: int, end: int} FALSE if not found, otherwise array with start and end
@@ -105,17 +108,19 @@ final class XmlUtil {
     string $blockType = 'w:p',
     int $offset = 0
   ): bool|array {
-    $pos = strpos($xml, $search, $offset);
-    if (FALSE === $pos) {
+    $pos = StringUtil::findPos($xml, $search, $offset);
+    if (NULL === $pos) {
       return FALSE;
     }
+
     $start = static::findXmlBlockStart($xml, $pos, $blockType);
     if (0 > $start) {
       return FALSE;
     }
+
     $end = static::findXmlBlockEnd($xml, $start, $blockType);
     // If not found or if resulting string does not contain the string we are searching for
-    if (0 > $end || strstr(static::getSlice($xml, $start, $end), $search) === FALSE) {
+    if (0 > $end || StringUtil::findPos(static::getSlice($xml, $start, $end), $search) === NULL) {
       return FALSE;
     }
 

--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -82,6 +82,50 @@ final class PhpWordTemplateProcessorTest extends TestCase {
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
+  public function testReplaceWithPreserveSpace(): void {
+    $mainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+             <w:t>Foo</w:t>
+            </w:r>
+            <w:r>
+             <w:t xml:space="preserve">  {place</w:t>
+            </w:r>
+            <w:r>
+             <w:t>.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
+    $templateProcessor->civiTokensToMacros();
+    $templateProcessor->replaceHtmlToken('place.holder', 'test 123');
+
+    $expectedMainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:t xml:space="preserve">Foo  </w:t>
+            </w:r>
+            <w:r>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+             <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
+  }
+
   public function testReplaceWithSplitToken(): void {
     // There's a run that splits the token, but doesn't have a visible impact.
     // It only provides an rsidR. The token shall be detected nevertheless.

--- a/tests/phpunit/Civi/Civioffice/PhpWord/Util/DocxUtilTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/Util/DocxUtilTest.php
@@ -76,6 +76,44 @@ final class DocxUtilTest extends TestCase {
       EOD,
     ];
 
+    // Run with xml:space attribute shall be combined.
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:t xml:space="replace">
+       Foo</w:t>
+            </w:r>
+            <w:r>
+              <w:t xml:space="preserve">  {place.</w:t>
+            </w:r>
+            <w:r>
+              <w:t>holder</w:t>
+            </w:r>
+            <w:r>
+              <w:t xml:space="collapse">}  </w:t>
+            </w:r>
+            <w:r>
+              <w:t>bar  </w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:t xml:space="preserve">  Foo  {place.holder} bar </w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+    ];
+
     $expectedWithStyle = <<<EOD
       <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
         <w:body>

--- a/tests/phpunit/Civi/Civioffice/PhpWord/Util/StringUtilTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/Util/StringUtilTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Civioffice\PhpWord\Util;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Civioffice\PhpWord\Util\StringUtil
+ */
+final class StringUtilTest extends TestCase {
+
+  public static function testFindPos(): void {
+    $string = '<w:r><w:t>a</w.t><w:t whitespace="preserve">b</w:t><w:t>c</w.t></w:r>';
+    static::assertSame(5, StringUtil::findPos($string, '<w:t'));
+    static::assertSame(5, StringUtil::findPos($string, '/<w:t( whitespace="[^"]+")?>/'));
+    static::assertSame(17, StringUtil::findPos($string, '/<w:t( whitespace="[^"]+")>/'));
+    static::assertSame(51, StringUtil::findPos($string, '<w:t>', 6));
+    static::assertSame(51, StringUtil::findPos($string, '/<w:t>/', 6));
+    static::assertNull(StringUtil::findPos($string, 'abc'));
+    static::assertNull(StringUtil::findPos($string, '/abc/'));
+  }
+
+  public static function testIsRegex(): void {
+    static::assertTrue(StringUtil::isRegex('/a/'));
+    static::assertTrue(StringUtil::isRegex('#a#'));
+    static::assertFalse(StringUtil::isRegex('ZaZ'));
+    static::assertFalse(StringUtil::isRegex('1a1'));
+  }
+
+}


### PR DESCRIPTION
Previously `DocxUtil::combineRuns()` only handled `w:t` tags without `xml:space` attribute.

systopia-reference: 30237