### PR TITLE
Handle additional content when combining runs

### DIFF
--- a/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/PhpWordTemplateProcessorTest.php
@@ -126,6 +126,56 @@ final class PhpWordTemplateProcessorTest extends TestCase {
     static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
   }
 
+  public function testReplaceWithAdditionalContent(): void {
+    // Contains w:tab in the second run.
+    $mainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+             <w:t>Foo</w:t>
+            </w:r>
+            <w:r>
+             <w:tab/>
+             <w:t xml:space="preserve">  {place</w:t>
+            </w:r>
+            <w:r>
+             <w:t>.holder} bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    $templateProcessor = new TestablePhpWordTemplateProcessor($mainPart);
+    $templateProcessor->civiTokensToMacros();
+    $templateProcessor->replaceHtmlToken('place.holder', 'test 123');
+
+    $expectedMainPart = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:t>Foo</w:t>
+            </w:r>
+            <w:r>
+              <w:tab/>
+              <w:t xml:space="preserve">  </w:t>
+            </w:r>
+            <w:r>
+              <w:t xml:space="preserve">test 123</w:t>
+            </w:r>
+            <w:r>
+             <w:t xml:space="preserve"> bar</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+
+    static::assertXmlStringEqualsXmlString($expectedMainPart, $templateProcessor->getMainPart());
+  }
+
   public function testReplaceWithSplitToken(): void {
     // There's a run that splits the token, but doesn't have a visible impact.
     // It only provides an rsidR. The token shall be detected nevertheless.

--- a/tests/phpunit/Civi/Civioffice/PhpWord/Util/DocxUtilTest.php
+++ b/tests/phpunit/Civi/Civioffice/PhpWord/Util/DocxUtilTest.php
@@ -76,6 +76,107 @@ final class DocxUtilTest extends TestCase {
       EOD,
     ];
 
+    // Run without rPr elements and additional content in first run shall be combined.
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:tab/>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r>
+              <w:t>holder</w:t>
+            </w:r>
+            <w:r>
+              <w:t>}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:tab/>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+    ];
+
+    // Run with rPr elements and additional content in first run shall be combined.
+    yield [<<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:tab/>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>holder</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:t>}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+      <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:rPr>
+                <w:b w:val="true"/>
+              </w:rPr>
+              <w:tab/>
+              <w:t>Foo {place.holder}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD,
+    ];
+
+    // Run with additional content in follow-up runs shall not be combined.
+    $withAdditionalContentInAllRuns = <<<EOD
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r>
+              <w:tab/>
+              <w:t>Foo {place.</w:t>
+            </w:r>
+            <w:r>
+              <w:tab/>
+              <w:t>holder</w:t>
+            </w:r>
+            <w:r>
+              <w:tab/>
+              <w:t>}</w:t>
+            </w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+      EOD;
+    yield [$withAdditionalContentInAllRuns, $withAdditionalContentInAllRuns];
+
     // Run with xml:space attribute shall be combined.
     yield [<<<EOD
       <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">


### PR DESCRIPTION
Runs might have [content](https://ooxml.info/docs/17/17.3/17.3.3/) apart from `w:t`. This change combines runs with the same run properties (`w:rPr`) even if the first run has content before the first `w:t`. The second run must not have content apart from `w:t` to be combined.

Note: The regular expression expects a possible `w:rPr` element to be the first child in a run. The specification says `w:rPr` *shall be the first child*. So in theory there might be cases where the result is not as expected, though I don't expect this to happen. (I don't know any application that doesn't put the `w:rPr` at the first position.)

systopia-reference: 30245