### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.54</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments/>
   <classloader>

--- a/templates/CRM/Civioffice/Form/DocumentUpload.tpl
+++ b/templates/CRM/Civioffice/Form/DocumentUpload.tpl
@@ -38,8 +38,8 @@
                 <td>{$document.size}</td>
                 <td>{$document.upload_date}</td>
                 <td>
-                  <span><a href="{$document.delete_link}" class="action-item crm-hover-button view-contact no-popup" title="{ts}Delete File{/ts}">{ts}Delete{/ts}</a></span>
-                  <span><a href="{$document.download_link}" class="action-item crm-hover-button view-contact no-popup" title="{ts}Download File{/ts}">{ts}Download{/ts}</a></span>
+                  <span><a href="{$document.delete_link}" class="action-item crm-hover-button view-contact no-popup" title="{ts escape='htmlattribute'}Delete File{/ts}">{ts}Delete{/ts}</a></span>
+                  <span><a href="{$document.download_link}" class="action-item crm-hover-button view-contact no-popup" title="{ts escape='htmlattribute'}Download File{/ts}">{ts}Download{/ts}</a></span>
                 </td>
               </tr>
             {/foreach}

--- a/templates/CRM/Civioffice/Form/Settings.tpl
+++ b/templates/CRM/Civioffice/Form/Settings.tpl
@@ -180,10 +180,10 @@
               <td>
                 <a class="button crm-popup crm-small-popup"
                    href="{crmURL p='civicrm/admin/civioffice/settings/livesnippet' q="reset=1&id=`$live_snippet_id`&action=update"}"
-                   title="{ts}Edit Live Snippet{/ts}">{ts}Edit{/ts}</a>
+                   title="{ts escape='htmlattribute'}Edit Live Snippet{/ts}">{ts}Edit{/ts}</a>
                 <a class="button crm-popup crm-small-popup"
                    href="{crmURL p='civicrm/admin/civioffice/settings/livesnippet' q="reset=1&id=`$live_snippet_id`&action=delete"}"
-                   title="{ts}Edit Live Snippet{/ts}">{ts}Delete{/ts}</a>
+                   title="{ts escape='htmlattribute'}Edit Live Snippet{/ts}">{ts}Delete{/ts}</a>
               </td>
 
             </tr>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.