### PR TITLE
Move upload document store from uploadDir to customFileUploadDir (fix CiviCRM 6.13 template loss)

### DIFF
--- a/CRM/Civioffice/DocumentStore/Upload.php
+++ b/CRM/Civioffice/DocumentStore/Upload.php
@@ -43,11 +43,6 @@ class CRM_Civioffice_DocumentStore_Upload extends CRM_Civioffice_DocumentStore {
   public function __construct(bool $common) {
     $this->common = $common;
 
-    // Persistent storage for uploaded document templates.
-    // Must NOT live under $config->uploadDir: the core "Clean-up Temporary
-    // Data and Files" scheduled job (active by default since CiviCRM 6.13,
-    // civicrm/civicrm-core#34924) calls CRM_Utils_File::cleanDir($uploadDir)
-    // recursively and would wipe every template.
     $config = CRM_Core_Config::singleton();
     $this->base_folder = $config->customFileUploadDir . 'civioffice_documents';
     if (!file_exists($this->base_folder)) {

--- a/CRM/Civioffice/DocumentStore/Upload.php
+++ b/CRM/Civioffice/DocumentStore/Upload.php
@@ -43,10 +43,13 @@ class CRM_Civioffice_DocumentStore_Upload extends CRM_Civioffice_DocumentStore {
   public function __construct(bool $common) {
     $this->common = $common;
 
-    // get the upload folder
+    // Persistent storage for uploaded document templates.
+    // Must NOT live under $config->uploadDir: the core "Clean-up Temporary
+    // Data and Files" scheduled job (active by default since CiviCRM 6.13,
+    // civicrm/civicrm-core#34924) calls CRM_Utils_File::cleanDir($uploadDir)
+    // recursively and would wipe every template.
     $config = CRM_Core_Config::singleton();
-    // working?
-    $this->base_folder = $config->uploadDir . 'civioffice_documents';
+    $this->base_folder = $config->customFileUploadDir . 'civioffice_documents';
     if (!file_exists($this->base_folder)) {
       mkdir($this->base_folder);
     }

--- a/CRM/Civioffice/Upgrader.php
+++ b/CRM/Civioffice/Upgrader.php
@@ -162,6 +162,46 @@ class CRM_Civioffice_Upgrader extends CRM_Extension_Upgrader_Base {
   }
 
   /**
+   * Move uploaded document templates from $config->uploadDir to
+   * $config->customFileUploadDir. The core "Clean-up Temporary Data and Files"
+   * scheduled job (civicrm/civicrm-core#34924, active by default since
+   * CiviCRM 6.13) recursively wipes uploadDir and would otherwise destroy all
+   * existing templates.
+   */
+  public function upgrade_0011(): bool {
+    $this->ctx->log->info(
+      'CiviOffice: moving upload templates from $config->uploadDir to '
+      . '$config->customFileUploadDir to avoid data loss from the core '
+      . 'cleanup job (active by default since CiviCRM 6.13).'
+    );
+
+    $config = CRM_Core_Config::singleton();
+    $legacy = rtrim($config->uploadDir, DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR . 'civioffice_documents';
+    $target = rtrim($config->customFileUploadDir, DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR . 'civioffice_documents';
+
+    if (!is_dir($legacy)) {
+      return TRUE;
+    }
+    CRM_Utils_File::createDir($target);
+
+    foreach (scandir($legacy) ?: [] as $entry) {
+      if ($entry === '.' || $entry === '..') {
+        continue;
+      }
+      $from = $legacy . DIRECTORY_SEPARATOR . $entry;
+      $to   = $target . DIRECTORY_SEPARATOR . $entry;
+      if (is_dir($from) && !file_exists($to)) {
+        rename($from, $to);
+      }
+    }
+    @rmdir($legacy);
+
+    return TRUE;
+  }
+
+  /**
    * Convert JSON-formatted setting "civioffice_renderers" to PHP-serialized format.
    * The setting was wrongly defined as JSON-formatted in settings metadata while unerialization with a format other
    * than PHP-serialized only works with the API. Civi::settings() always expects and generates PHP-serialized values.

--- a/CRM/Civioffice/Upgrader.php
+++ b/CRM/Civioffice/Upgrader.php
@@ -176,11 +176,11 @@ class CRM_Civioffice_Upgrader extends CRM_Extension_Upgrader_Base {
     );
 
     $config = CRM_Core_Config::singleton();
-    // @phpstan-ignore argument.type
-    $legacy = rtrim($config->uploadDir, DIRECTORY_SEPARATOR)
-      . DIRECTORY_SEPARATOR . 'civioffice_documents';
-    $target = rtrim($config->customFileUploadDir, DIRECTORY_SEPARATOR)
-      . DIRECTORY_SEPARATOR . 'civioffice_documents';
+    // $config->uploadDir / $config->customFileUploadDir are guaranteed to end
+    // with a directory separator, so concatenate directly as in
+    // CRM_Civioffice_DocumentStore_Upload.
+    $legacy = $config->uploadDir . 'civioffice_documents';
+    $target = $config->customFileUploadDir . 'civioffice_documents';
 
     if (!is_dir($legacy)) {
       return TRUE;

--- a/CRM/Civioffice/Upgrader.php
+++ b/CRM/Civioffice/Upgrader.php
@@ -176,22 +176,24 @@ class CRM_Civioffice_Upgrader extends CRM_Extension_Upgrader_Base {
     );
 
     $config = CRM_Core_Config::singleton();
+    // @phpstan-ignore argument.type
     $legacy = rtrim($config->uploadDir, DIRECTORY_SEPARATOR)
-            . DIRECTORY_SEPARATOR . 'civioffice_documents';
+      . DIRECTORY_SEPARATOR . 'civioffice_documents';
     $target = rtrim($config->customFileUploadDir, DIRECTORY_SEPARATOR)
-            . DIRECTORY_SEPARATOR . 'civioffice_documents';
+      . DIRECTORY_SEPARATOR . 'civioffice_documents';
 
     if (!is_dir($legacy)) {
       return TRUE;
     }
     CRM_Utils_File::createDir($target);
-
-    foreach (scandir($legacy) ?: [] as $entry) {
+    $entries = scandir($legacy);
+    $entries = is_array($entries) ? $entries : [];
+    foreach ($entries as $entry) {
       if ($entry === '.' || $entry === '..') {
         continue;
       }
       $from = $legacy . DIRECTORY_SEPARATOR . $entry;
-      $to   = $target . DIRECTORY_SEPARATOR . $entry;
+      $to = $target . DIRECTORY_SEPARATOR . $entry;
       if (is_dir($from) && !file_exists($to)) {
         rename($from, $to);
       }

--- a/CRM/Civioffice/Upgrader.php
+++ b/CRM/Civioffice/Upgrader.php
@@ -176,9 +176,6 @@ class CRM_Civioffice_Upgrader extends CRM_Extension_Upgrader_Base {
     );
 
     $config = CRM_Core_Config::singleton();
-    // $config->uploadDir / $config->customFileUploadDir are guaranteed to end
-    // with a directory separator, so concatenate directly as in
-    // CRM_Civioffice_DocumentStore_Upload.
     $legacy = $config->uploadDir . 'civioffice_documents';
     $target = $config->customFileUploadDir . 'civioffice_documents';
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1116,6 +1116,12 @@ parameters:
 			path: CRM/Civioffice/Upgrader.php
 
 		-
+			message: '#^Binary operation "\." between mixed and ''civioffice_documents'' results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: CRM/Civioffice/Upgrader.php
+
+		-
 			message: '#^Call to an undefined method object\:\:fetch\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -19,8 +19,3 @@ parameters:
 		-
 			message: '#Dead catch - CRM_Core_Exception is never thrown in the try block.#'
 			path: */Civi/Civioffice/EventSubscriber/ParticipantCiviOfficeTokenSubscriber.php
-
-		# Required with CiviCRM Core <6.1.0
-		-
-			message: '#^Parameter \#1 \$string of function rtrim expects string, mixed given\.$#'
-			path: CRM/Civioffice/Upgrader.php

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -19,3 +19,8 @@ parameters:
 		-
 			message: '#Dead catch - CRM_Core_Exception is never thrown in the try block.#'
 			path: */Civi/Civioffice/EventSubscriber/ParticipantCiviOfficeTokenSubscriber.php
+
+		# Required with CiviCRM Core <6.1.0
+		-
+			message: '#^Parameter \#1 \$string of function rtrim expects string, mixed given\.$#'
+			path: CRM/Civioffice/Upgrader.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ parameters:
 		- civioffice.php
 	excludePaths:
 		analyse:
+			- CRM/Civioffice/CustomData.php
 			- CRM/Civioffice/DAO/*
 			- tests/phpunit/bootstrap.php
 	scanFiles:


### PR DESCRIPTION
Fixes #132.

*systopia-reference: 32288*

## What

`CRM_Civioffice_DocumentStore_Upload` now stores templates under `$config->customFileUploadDir . 'civioffice_documents'` instead of `$config->uploadDir . 'civioffice_documents'`. A new `Upgrader::upgrade_0011` moves any existing `common/` and `contact_<id>/` subdirectories from the legacy location to the new one and removes the empty legacy parent (idempotent on retry).

## Why

`$config->uploadDir` is CiviCRM's transient staging area. The "Clean-up Temporary Data and Files" scheduled job — enabled by default since CiviCRM 6.13 (civicrm/civicrm-core#34924) — calls `CRM_Utils_File::cleanDir($uploadDir)` recursively and was silently destroying every CiviOffice template each week.

`$config->customFileUploadDir` is the matching CiviCRM concept for persistent user-uploaded files: not touched by the cleanup job, auto-protected from web access by `restrictAccess()`, available on every supported CMS.

See the linked issue for the full root-cause analysis.

## Local verification

Reproduced and verified using a `civicrm/civicrm:6.13` Docker stack with CiviOffice mounted as a volume, then repeated on `civicrm/civicrm:6.14`:

| Scenario | Result |
|---|---|
| 6.13.3 — unpatched: drop `.docx` into `uploadDir/civioffice_documents/`, run `cv api Job.cleanup tempFiles=1` | template gone (bug reproduced) |
| 6.13.3 — patched: same test against `customFileUploadDir/civioffice_documents/` | template survives |
| 6.13.3 — patched: pre-existing legacy templates under `uploadDir/civioffice_documents/{common,contact_1,contact_99}/` + run `cv api Extension.upgrade` | all four files end up under `customFileUploadDir/civioffice_documents/...` with content intact; legacy dir removed |
| 6.14.0 — patched: same fix verification | template survives; uploadDir-side still wiped by core (as expected) |
