### PR TITLE
AttachmentProvider: store provider values under "extra" (de.systopia.mailattachment shape)

### DIFF
--- a/CRM/Civioffice/AttachmentProvider.php
+++ b/CRM/Civioffice/AttachmentProvider.php
@@ -105,11 +105,17 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         ['class' => 'crm-select2']
     );
 
+    // Provider-specific defaults are stored under "extra" (mailattachment
+    // attachment shape); fall back to legacy top-level keys for configurations
+    // saved before that change.
+    $default_extra = $defaults['extra'] ?? NULL;
+    $dv = is_array($default_extra) ? $default_extra : $defaults;
+
     // Add Live Snippets.
     $live_snippet_elements = CRM_Civioffice_LiveSnippets::addFormElements(
         $form,
         $prefix . 'attachments--' . $attachment_id . '--',
-        $defaults['live_snippets'] ?? []
+        $dv['live_snippets'] ?? []
     );
 
     $form->add(
@@ -123,9 +129,9 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
     $form->setDefaults(
         [
           $prefix . 'attachments--' . $attachment_id . '--document_renderer_uri'
-          => $defaults['document_renderer_uri'] ?? NULL,
-          $prefix . 'attachments--' . $attachment_id . '--document_uri' => $defaults['document_uri'] ?? NULL,
-          $prefix . 'attachments--' . $attachment_id . '--target_mime_type' => $defaults['target_mime_type'] ?? NULL,
+          => $dv['document_renderer_uri'] ?? NULL,
+          $prefix . 'attachments--' . $attachment_id . '--document_uri' => $dv['document_uri'] ?? NULL,
+          $prefix . 'attachments--' . $attachment_id . '--target_mime_type' => $dv['target_mime_type'] ?? NULL,
           $prefix . 'attachments--' . $attachment_id . '--name' => $defaults['name'] ?? NULL,
         ]
     );
@@ -155,28 +161,39 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
         $prefix . 'attachments--' . $attachment_id . '--'
     );
     return [
-      'document_renderer_uri' => $values[$prefix . 'attachments--' . $attachment_id . '--document_renderer_uri'],
-      'document_uri' => $values[$prefix . 'attachments--' . $attachment_id . '--document_uri'],
-      'target_mime_type' => $values[$prefix . 'attachments--' . $attachment_id . '--target_mime_type'],
       'name' => $values[$prefix . 'attachments--' . $attachment_id . '--name'],
-      'live_snippets' => $live_snippet_values,
+      // Provider-specific values go into "extra" per the mailattachment
+      // attachment shape (array{path, name, template_id, extra?}).
+      'extra' => [
+        'document_renderer_uri' => $values[$prefix . 'attachments--' . $attachment_id . '--document_renderer_uri'],
+        'document_uri' => $values[$prefix . 'attachments--' . $attachment_id . '--document_uri'],
+        'target_mime_type' => $values[$prefix . 'attachments--' . $attachment_id . '--target_mime_type'],
+        'live_snippets' => $live_snippet_values,
+      ],
     ];
   }
 
   /**
    * {@inheritDoc}
+   *
+   * @phpstan-param array<string, mixed> $attachment_values
    */
   public static function buildAttachment($context, $attachment_values) {
+    // Provider-specific values live under "extra" (mailattachment attachment
+    // shape); fall back to the legacy top-level keys for configurations saved
+    // before that change.
+    $extra = $attachment_values['extra'] ?? NULL;
+    $values = is_array($extra) ? $extra : $attachment_values;
     $civioffice_result = civicrm_api3(
         'CiviOffice',
         'convert',
         [
-          'document_uri' => $attachment_values['document_uri'],
+          'document_uri' => $values['document_uri'],
           'entity_ids' => [$context['entity_id']],
           'entity_type' => $context['entity_type'],
-          'renderer_uri' => $attachment_values['document_renderer_uri'],
-          'target_mime_type' => $attachment_values['target_mime_type'],
-          'live_snippets' => $attachment_values['live_snippets'],
+          'renderer_uri' => $values['document_renderer_uri'],
+          'target_mime_type' => $values['target_mime_type'],
+          'live_snippets' => $values['live_snippets'],
         ]
     );
     if (!empty($civioffice_result['is_error']) || empty($civioffice_result['values'][0])) {
@@ -184,25 +201,26 @@ class CRM_Civioffice_AttachmentProvider implements EventSubscriberInterface, Att
     }
     $result_store_uri = $civioffice_result['values'][0];
     $result_store = CRM_Civioffice_Configuration::getDocumentStore($result_store_uri);
+    $name = is_string($attachment_values['name'] ?? NULL) ? $attachment_values['name'] : '';
     foreach ($result_store->getDocuments() as $document) {
       $attachment_file = $document->getLocalTempCopy();
       $mime_type = Attachments::getMimeType($attachment_file);
       $file_extension = CRM_Civioffice_MimeType::mapMimeTypeToFileExtension($mime_type);
 
       if (
-        !empty($attachment_values['name'])
-        && !empty($name_parts = explode('.', $attachment_values['name']))
+        !empty($name)
+        && !empty($name_parts = explode('.', $name))
         && end($name_parts) != $file_extension
       ) {
-        $attachment_values['name'] .= '.' . $file_extension;
+        $name .= '.' . $file_extension;
       }
       else {
-        $attachment_values['name'] = $document->getName();
+        $name = $document->getName();
       }
       $attachment = [
         'fullPath' => $attachment_file,
         'mime_type' => $mime_type,
-        'cleanName' => $attachment_values['name'] ?: $document->getName(),
+        'cleanName' => $name ?: $document->getName(),
       ];
     }
     return $attachment ?? NULL;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,30 +66,6 @@ parameters:
 			path: CRM/Civioffice/AttachmentProvider.php
 
 		-
-			message: '#^Offset ''document_renderer_uri'' does not exist on array\{path\: string, name\: string, extra\?\: mixed\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Civioffice/AttachmentProvider.php
-
-		-
-			message: '#^Offset ''document_uri'' does not exist on array\{path\: string, name\: string, extra\?\: mixed\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Civioffice/AttachmentProvider.php
-
-		-
-			message: '#^Offset ''live_snippets'' does not exist on array\{path\: string, name\: string, extra\?\: mixed\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Civioffice/AttachmentProvider.php
-
-		-
-			message: '#^Offset ''target_mime_type'' does not exist on array\{path\: string, name\: string, extra\?\: mixed\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Civioffice/AttachmentProvider.php
-
-		-
 			message: '#^Parameter \#3 \$defaults of static method CRM_Civioffice_LiveSnippets\:\:addFormElements\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
Follow-up to the discussion on #133 (per @dontub: *"Actually `AttachmentProvider` should be modified to be compliant with the current version of `de.systopia.mailattachment`."*).

## What

`Civi\Mailattachment\AttachmentType\AttachmentTypeInterface::buildAttachment()` types `$attachment_values` as `array{path, name, template_id, extra?: mixed}`, with `extra` as the designated slot for provider-specific data. CiviOffice kept `document_uri` / `document_renderer_uri` / `target_mime_type` / `live_snippets` at the top level — no longer matching the shape (4 × PHPStan `offsetAccess.notFound`, currently failing PHPStan CI on master and every PR).

- `processAttachmentForm()` now nests those fields under `extra`.
- `buildAttachment()` and the `buildAttachmentForm()` defaults read them from `extra`, with a fallback to the legacy top-level keys so attachment configurations saved before this change keep working (they are migrated to the new shape on their next save).
- The now-obsolete PHPStan baseline entries are removed.

## Verification

- PHPStan (`phpstan.ci.neon`): no errors for `AttachmentProvider.php`.
- Runtime, in a `civicrm/civicrm` 6.14 Docker stack (CiviOffice + mailattachment 1.2.0-dev + MailBatch 2.2.0-dev, unoconv/LibreOffice renderer): `buildAttachment()` renders a PDF for **both** shapes — the new `extra` shape and a crafted legacy flat config (BC fallback).
- Browser end-to-end (Playwright): configuring a "CiviOffice Document" attachment in the MailBatch send form and sending delivers the e-mail with the rendered PDF (named as entered in the form) to the mail catcher.

Note: PHPStan CI on this branch still reports the pre-existing `CRM/Civioffice/CustomData.php` errors; #133 excludes that vendored helper from analysis, so they clear once #133 reaches master.

Heads-up: exercising the MailBatch send path end-to-end also requires the `entity_ids` fix from #135 (consumers pass string entity IDs per the mailattachment contract, which `strict_types` rejects further down).

## Open question

The declared shape marks `path` and `template_id` as *required*, but neither is meaningful for CiviOffice — the document only comes into existence at render time (`FileOnServer` sets `path`; `template_id` is consumer-set). This PR therefore doesn't produce them, so the configurations CiviOffice stores still don't fully satisfy the declared shape. Two possible resolutions:

1. CiviOffice sets placeholder values (`path => ''`, `template_id => 0`) in `processAttachmentForm()` — satisfies the letter of the contract, but with meaningless data.
2. The `AttachmentTypeInterface` shape marks them as optional (`path?`, `template_id?`), since they are provider-specific — that would be a change in de.systopia.mailattachment.

Happy to implement option 1 here if preferred.

