### PR TITLE
Convert API: cast entity_ids to int

### DIFF
--- a/api/v3/CiviOffice/Convert.php
+++ b/api/v3/CiviOffice/Convert.php
@@ -82,8 +82,11 @@ function _civicrm_api3_civi_office_convert_spec(array &$spec): void {
 function civicrm_api3_civi_office_convert(array $params): array {
   /** @var string $documentUri */
   $documentUri = $params['document_uri'];
-  /** @phpstan-var list<int> $entityIds */
-  $entityIds = $params['entity_ids'];
+  /** @phpstan-var list<int|numeric-string> $rawEntityIds */
+  $rawEntityIds = $params['entity_ids'];
+  // Consumers (e.g. de.systopia.mailattachment implementations) may pass entity
+  // IDs as strings; the token processor requires int.
+  $entityIds = array_map(fn ($entityId) => (int) $entityId, $rawEntityIds);
   /** @var string $entityType */
   $entityType = $params['entity_type'];
   /** @var string $rendererUri */

--- a/api/v3/CiviOffice/Convert.php
+++ b/api/v3/CiviOffice/Convert.php
@@ -69,31 +69,25 @@ function _civicrm_api3_civi_office_convert_spec(array &$spec): void {
 }
 
 /**
- * CiviOffice.convert: Converter
- *
- * @phpstan-param array<string, mixed> $params
- *   API call parameters
+ * @phpstan-param array{
+ *   document_uri: string,
+ *   entity_ids: list<int|numeric-string>,
+ *   entity_type: string,
+ *   renderer_uri: string,
+ *   target_mime_type: string,
+ *   live_snippets: array<string, string>
+ * } $params
  *
  * @phpstan-return array<string, mixed>
- *   API3 response
  *
  * @throws \CRM_Core_Exception
  */
 function civicrm_api3_civi_office_convert(array $params): array {
-  /** @var string $documentUri */
   $documentUri = $params['document_uri'];
-  /** @phpstan-var list<int|numeric-string> $rawEntityIds */
-  $rawEntityIds = $params['entity_ids'];
-  // Consumers (e.g. de.systopia.mailattachment implementations) may pass entity
-  // IDs as strings; the token processor requires int.
-  $entityIds = array_map(fn ($entityId) => (int) $entityId, $rawEntityIds);
-  /** @var string $entityType */
+  $entityIds = array_map(fn ($entityId) => (int) $entityId, $params['entity_ids']);
   $entityType = $params['entity_type'];
-  /** @var string $rendererUri */
   $rendererUri = $params['renderer_uri'];
-  /** @var string $targetMimeType */
   $targetMimeType = $params['target_mime_type'];
-  /** @phpstan-var array<string, string> $liveSnippets */
   $liveSnippets = $params['live_snippets'];
 
   $configuration = CRM_Civioffice_Configuration::getConfig();


### PR DESCRIPTION
## What

Cast `entity_ids` to `int` in `CiviOffice.convert`.

## Why

Calling `civicrm_api3('CiviOffice', 'convert', …)` with string entity IDs (e.g. `['3']`) crashes:

```
Civi\Civioffice\Token\CiviOfficeTokenProcessor::replaceTokens(): Argument #4 ($entityId)
must be of type int, string given, called in api/v3/CiviOffice/Convert.php on line 124
```

This breaks the mailattachment integration in practice: `Civi\Mailattachment\AttachmentType\AttachmentTypeInterface` declares `$context['entity_id']` as **string**, and consumers like de.systopia.mailbatch pass DB-sourced string IDs — so sending a CiviOffice document attachment via MailBatch currently fails. The API3 spec declares `entity_ids` as `T_INT`, but API3 does not coerce array elements, and `Convert.php` feeds them straight into the strictly-typed `replaceTokens()`.

Reproduced and verified in a `civicrm/civicrm` 6.14 Docker stack (PHP 8.4, CiviOffice master + mailattachment 1.2.0-dev + MailBatch 2.2.0-dev): without this change the MailBatch send task crashes as above; with it, the e-mail with the rendered document is delivered. PHPStan (`phpstan.ci.neon`) reports no errors for the changed file.

Related observation while debugging: the mailattachment contract prescribes a *lowercase* `entity_type` ("the lowercase name of the CiviCRM entity type"), while CiviOffice logs a deprecation for lowercase entity types — the two contracts may want aligning at some point.
