### PR TITLE
Fix TypeError in download form when return_url parameter is missing

### DIFF
--- a/CRM/Civioffice/Form/Download.php
+++ b/CRM/Civioffice/Form/Download.php
@@ -42,7 +42,7 @@ class CRM_Civioffice_Form_Download extends CRM_Core_Form {
       \CRM_Utils_System::civiExit(404);
     }
 
-    $this->return_url = CRM_Utils_Request::retrieve('return_url', 'String', $this);
+    $this->return_url = CRM_Utils_Request::retrieve('return_url', 'String', $this) ?? '';
     $instant_download = (bool) CRM_Utils_Request::retrieve('instant_download', 'Boolean', $this);
 
     if ($instant_download) {


### PR DESCRIPTION
`CRM_Utils_Request::retrieve()` returns `NULL` when the `return_url` parameter is absent (e.g. in the SearchKit instant download flow), which crashes since the property was typed `string` in 73e1107: `Cannot assign null to property CRM_Civioffice_Form_Download::$return_url of type string`.