### PR TITLE
Allow underscores in API4 entity names

### DIFF
--- a/Civi/Civioffice/Api4/Action/Civioffice/RenderWebAction.php
+++ b/Civi/Civioffice/Api4/Action/Civioffice/RenderWebAction.php
@@ -110,7 +110,11 @@ class RenderWebAction extends AbstractAction {
   }
 
   public function setEntityType(string $entityType): self {
-    Assertion::alnum($entityType, 'entityType must only contain alpha-numeric characters.');
+    Assertion::regex(
+    	$entityType, 
+    	'/^[a-zA-Z0-9_]+$/', 
+    	'entityType must only contain alpha-numeric characters or underscores.'
+    );
     $this->entityType = $entityType;
 
     return $this;

--- a/Civi/Civioffice/Api4/Action/Civioffice/RenderWebAction.php
+++ b/Civi/Civioffice/Api4/Action/Civioffice/RenderWebAction.php
@@ -111,9 +111,9 @@ class RenderWebAction extends AbstractAction {
 
   public function setEntityType(string $entityType): self {
     Assertion::regex(
-    	$entityType, 
-    	'/^[a-zA-Z0-9_]+$/', 
-    	'entityType must only contain alpha-numeric characters or underscores.'
+      $entityType,
+      '/^[a-zA-Z0-9_]+$/',
+      'entityType must only contain alpha-numeric characters or underscores.'
     );
     $this->entityType = $entityType;
 


### PR DESCRIPTION
## Problem

RenderWebAction currently validates the entity type using
Assertion::alnum().

This rejects API4 entity names containing underscores, for example:

    Custom_Utilisation_du_corps

Such entity names are valid API4 entities provided by extensions,
but cannot currently be used by CiviOffice SearchKit tasks.

## Solution

Replace Assertion::alnum() with a regular expression accepting
letters, numbers and underscores.

## Tested

- CiviCRM 6.11
- CiviOffice 2.x
- Custom API4 entity from an extension

The SearchKit RenderWeb action now works correctly.

Fixes #142 